### PR TITLE
Add Linux support

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function createMainWindow() {
 		'show': false,
 		'width': 800,
 		'height': 600,
-		'icon': 'media/Icon.png',
+		'icon': path.join(__dirname, 'media', 'Icon.png'),
 		'min-width': 400,
 		'min-height': 200,
 		'title-bar-style': 'hidden-inset',

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function createMainWindow() {
 		'show': false,
 		'width': 800,
 		'height': 600,
+		'icon': 'media/Icon.png',
 		'min-width': 400,
 		'min-height': 200,
 		'title-bar-style': 'hidden-inset',

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ require('crash-reporter').start();
 let mainWindow;
 
 function updateBadge(title) {
+	// don't try to update the dock icon if the system has no dock
+	if (!app.dock) {
+		return;
+	}
 	// ignore `Sindre messaged you` blinking
 	if (title.indexOf('Messenger') === -1) {
 		return;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ require('crash-reporter').start();
 let mainWindow;
 
 function updateBadge(title) {
-	// don't try to update the dock icon if the system has no dock
 	if (!app.dock) {
 		return;
 	}

--- a/menu.js
+++ b/menu.js
@@ -12,69 +12,6 @@ function sendAction(action) {
 
 const tpl = [
 	{
-		label: appName,
-		submenu: [
-			{
-				label: `About ${appName}`,
-				role: 'about'
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Preferences...',
-				accelerator: 'Cmd+,',
-				click() {
-					sendAction('show-preferences');
-				}
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Log Out',
-				click() {
-					sendAction('log-out');
-				}
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Services',
-				role: 'services',
-				submenu: []
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: `Hide ${appName}`,
-				accelerator: 'Cmd+H',
-				role: 'hide'
-			},
-			{
-				label: 'Hide Others',
-				accelerator: 'Cmd+Shift+H',
-				role: 'hideothers'
-			},
-			{
-				label: 'Show All',
-				role: 'unhide'
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: `Quit ${appName}`,
-				accelerator: 'Cmd+Q',
-				click() {
-					app.quit();
-				}
-			}
-		]
-	},
-	{
 		label: 'File',
 		submenu: [
 			{
@@ -137,13 +74,6 @@ const tpl = [
 				label: 'Close',
 				accelerator: 'CmdOrCtrl+W',
 				role: 'close'
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Bring All to Front',
-				role: 'front'
 			}
 		]
 	},
@@ -174,5 +104,85 @@ ${process.platform} ${process.arch} ${os.release()}`;
 		]
 	}
 ];
+
+const appMenu = [
+	{
+		label: `About ${appName}`,
+		role: 'about'
+	},
+	{
+		type: 'separator'
+	},
+	{
+		label: 'Preferences...',
+		accelerator: 'CmdOrCtrl+,',
+		click() {
+			sendAction('show-preferences');
+		}
+	},
+	{
+		type: 'separator'
+	},
+	{
+		label: 'Log Out',
+		click() {
+			sendAction('log-out');
+		}
+	}
+];
+
+if (process.platform === 'darwin') {
+	// add primary menu with app name
+	tpl.unshift({
+		label: appName,
+		submenu: appMenu
+	});
+
+	// add OS X-only hide options
+	tpl[0].submenu.push([{
+		type: 'separator'
+	},
+	{
+		label: `Hide ${appName}`,
+		accelerator: 'CmdOrCtrl+H',
+		role: 'hide'
+	},
+	{
+		label: 'Hide Others',
+		accelerator: 'CmdOrCtrl+Shift+H',
+		role: 'hideothers'
+	},
+	{
+		label: 'Show All',
+		role: 'unhide'
+	}]);
+
+	tpl[3].submenu.push(
+		{
+			type: 'separator'
+		},
+		{
+			label: 'Bring All to Front',
+			role: 'front'
+		}
+	);
+} else {
+	// add main menu items to File menu
+	tpl[0].submenu = tpl[0].submenu.concat(appMenu);
+}
+
+// add quit to either app menu or File
+tpl[0].submenu.push(
+	{
+		type: 'separator'
+	},
+	{
+		label: `Quit ${appName}`,
+		accelerator: 'CmdOrCtrl+Q',
+		click() {
+			app.quit();
+		}
+	}
+);
 
 module.exports = Menu.buildFromTemplate(tpl);

--- a/menu.js
+++ b/menu.js
@@ -10,179 +10,279 @@ function sendAction(action) {
 	BrowserWindow.getFocusedWindow().webContents.send(action);
 }
 
-const tpl = [
-	{
-		label: 'File',
-		submenu: [
-			{
-				label: 'New Conversation',
-				accelerator: 'CmdOrCtrl+N',
-				click() {
-					sendAction('new-conversation');
-				}
-			}
-		]
-	},
-	{
-		label: 'Edit',
-		submenu: [
-			{
-				label: 'Undo',
-				accelerator: 'CmdOrCtrl+Z',
-				role: 'undo'
-			},
-			{
-				label: 'Redo',
-				accelerator: 'Shift+CmdOrCtrl+Z',
-				role: 'redo'
-			},
-			{
-				type: 'separator'
-			},
-			{
-				label: 'Cut',
-				accelerator: 'CmdOrCtrl+X',
-				role: 'cut'
-			},
-			{
-				label: 'Copy',
-				accelerator: 'CmdOrCtrl+C',
-				role: 'copy'
-			},
-			{
-				label: 'Paste',
-				accelerator: 'CmdOrCtrl+V',
-				role: 'paste'
-			},
-			{
-				label: 'Select All',
-				accelerator: 'CmdOrCtrl+A',
-				role: 'selectall'
-			}
-		]
-	},
-	{
-		label: 'Window',
-		role: 'window',
-		submenu: [
-			{
-				label: 'Minimize',
-				accelerator: 'CmdOrCtrl+M',
-				role: 'minimize'
-			},
-			{
-				label: 'Close',
-				accelerator: 'CmdOrCtrl+W',
-				role: 'close'
-			}
-		]
-	},
-	{
-		label: 'Help',
-		role: 'help',
-		submenu: [
-			{
-				label: 'Website',
-				click() {
-					shell.openExternal('https://github.com/sindresorhus/caprine');
-				}
-			},
-			{
-				label: 'Report Issue',
-				click() {
-					const body = `
-**Please succinctly describe your issue and steps to reproduce it.**
-
--
-
-${app.getName()} ${app.getVersion()}
-${process.platform} ${process.arch} ${os.release()}`;
-
-					shell.openExternal(`https://github.com/sindresorhus/caprine/issues/new?body=${encodeURIComponent(body)}`);
-				}
-			}
-		]
-	}
-];
-
-const appMenu = [
-	{
-		label: `About ${appName}`,
-		role: 'about'
-	},
-	{
-		type: 'separator'
-	},
-	{
-		label: 'Preferences...',
-		accelerator: 'CmdOrCtrl+,',
-		click() {
-			sendAction('show-preferences');
-		}
-	},
-	{
-		type: 'separator'
-	},
-	{
-		label: 'Log Out',
-		click() {
-			sendAction('log-out');
-		}
-	}
-];
+let tpl;
 
 if (process.platform === 'darwin') {
-	// add primary menu with app name
-	tpl.unshift({
-		label: appName,
-		submenu: appMenu
-	});
-
-	// add OS X-only hide options
-	tpl[0].submenu.push([{
-		type: 'separator'
-	},
-	{
-		label: `Hide ${appName}`,
-		accelerator: 'CmdOrCtrl+H',
-		role: 'hide'
-	},
-	{
-		label: 'Hide Others',
-		accelerator: 'CmdOrCtrl+Shift+H',
-		role: 'hideothers'
-	},
-	{
-		label: 'Show All',
-		role: 'unhide'
-	}]);
-
-	tpl[3].submenu.push(
+	tpl = [
 		{
-			type: 'separator'
+			label: appName,
+			submenu: [
+				{
+					label: `About ${appName}`,
+					role: 'about'
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Preferences...',
+					accelerator: 'Cmd+,',
+					click() {
+						sendAction('show-preferences');
+					}
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Log Out',
+					click() {
+						sendAction('log-out');
+					}
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Services',
+					role: 'services',
+					submenu: []
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: `Hide ${appName}`,
+					accelerator: 'Cmd+H',
+					role: 'hide'
+				},
+				{
+					label: 'Hide Others',
+					accelerator: 'Cmd+Shift+H',
+					role: 'hideothers'
+				},
+				{
+					label: 'Show All',
+					role: 'unhide'
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: `Quit ${appName}`,
+					accelerator: 'Cmd+Q',
+					click() {
+						app.quit();
+					}
+				}
+			]
 		},
 		{
-			label: 'Bring All to Front',
-			role: 'front'
-		}
-	);
-} else {
-	// add main menu items to File menu
-	tpl[0].submenu = tpl[0].submenu.concat(appMenu);
-}
+			label: 'File',
+			submenu: [
+				{
+					label: 'New Conversation',
+					accelerator: 'CmdOrCtrl+N',
+					click() {
+						sendAction('new-conversation');
+					}
+				}
+			]
+		},
+		{
+			label: 'Edit',
+			submenu: [
+				{
+					label: 'Undo',
+					accelerator: 'CmdOrCtrl+Z',
+					role: 'undo'
+				},
+				{
+					label: 'Redo',
+					accelerator: 'Shift+CmdOrCtrl+Z',
+					role: 'redo'
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Cut',
+					accelerator: 'CmdOrCtrl+X',
+					role: 'cut'
+				},
+				{
+					label: 'Copy',
+					accelerator: 'CmdOrCtrl+C',
+					role: 'copy'
+				},
+				{
+					label: 'Paste',
+					accelerator: 'CmdOrCtrl+V',
+					role: 'paste'
+				},
+				{
+					label: 'Select All',
+					accelerator: 'CmdOrCtrl+A',
+					role: 'selectall'
+				}
+			]
+		},
+		{
+			label: 'Window',
+			role: 'window',
+			submenu: [
+				{
+					label: 'Minimize',
+					accelerator: 'CmdOrCtrl+M',
+					role: 'minimize'
+				},
+				{
+					label: 'Close',
+					accelerator: 'CmdOrCtrl+W',
+					role: 'close'
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Bring All to Front',
+					role: 'front'
+				}
+			]
+		},
+		{
+			label: 'Help',
+			role: 'help',
+			submenu: [
+				{
+					label: 'Website',
+					click() {
+						shell.openExternal('https://github.com/sindresorhus/caprine');
+					}
+				},
+				{
+					label: 'Report Issue',
+					click() {
+						const body = `
+		**Please succinctly describe your issue and steps to reproduce it.**
 
-// add quit to either app menu or File
-tpl[0].submenu.push(
-	{
-		type: 'separator'
-	},
-	{
-		label: `Quit ${appName}`,
-		accelerator: 'CmdOrCtrl+Q',
-		click() {
-			app.quit();
+		-
+
+		${app.getName()} ${app.getVersion()}
+		${process.platform} ${process.arch} ${os.release()}`;
+
+						shell.openExternal(`https://github.com/sindresorhus/caprine/issues/new?body=${encodeURIComponent(body)}`);
+					}
+				}
+			]
 		}
-	}
-);
+	];
+} else {
+	tpl = [
+		{
+			label: 'File',
+			submenu: [
+				{
+					label: 'New Conversation',
+					accelerator: 'CmdOrCtrl+N',
+					click() {
+						sendAction('new-conversation');
+					}
+				},
+				{
+					label: 'Log Out',
+					click() {
+						sendAction('log-out');
+					}
+				},
+				{
+					label: `Quit ${appName}`,
+					accelerator: 'CmdOrCtrl+Q',
+					click() {
+						app.quit();
+					}
+				}
+			]
+		},
+		{
+			label: 'Edit',
+			submenu: [
+				{
+					label: 'Undo',
+					accelerator: 'CmdOrCtrl+Z',
+					role: 'undo'
+				},
+				{
+					label: 'Redo',
+					accelerator: 'Shift+CmdOrCtrl+Z',
+					role: 'redo'
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Cut',
+					accelerator: 'CmdOrCtrl+X',
+					role: 'cut'
+				},
+				{
+					label: 'Copy',
+					accelerator: 'CmdOrCtrl+C',
+					role: 'copy'
+				},
+				{
+					label: 'Paste',
+					accelerator: 'CmdOrCtrl+V',
+					role: 'paste'
+				},
+				{
+					label: 'Select All',
+					accelerator: 'CmdOrCtrl+A',
+					role: 'selectall'
+				},
+				{
+					type: 'separator'
+				},
+				{
+					label: 'Preferences',
+					accelerator: 'CmdOrCtrl+,',
+					click() {
+						sendAction('show-preferences');
+					}
+				}
+			]
+		},
+		{
+			label: 'Help',
+			role: 'help',
+			submenu: [
+				{
+					label: 'Website',
+					click() {
+						shell.openExternal('https://github.com/sindresorhus/caprine');
+					}
+				},
+				{
+					label: 'Report Issue',
+					click() {
+						const body = `
+		**Please succinctly describe your issue and steps to reproduce it.**
+
+		-
+
+		${app.getName()} ${app.getVersion()}
+		${process.platform} ${process.arch} ${os.release()}`;
+
+						shell.openExternal(`https://github.com/sindresorhus/caprine/issues/new?body=${encodeURIComponent(body)}`);
+					}
+				},
+				{
+					label: `About ${appName}`,
+					role: 'about'
+				}
+			]
+		}
+	];
+}
 
 module.exports = Menu.buildFromTemplate(tpl);

--- a/menu.js
+++ b/menu.js
@@ -10,279 +10,256 @@ function sendAction(action) {
 	BrowserWindow.getFocusedWindow().webContents.send(action);
 }
 
+const darwinTpl = [
+	{
+		label: appName,
+		submenu: [
+			{
+				label: `About ${appName}`,
+				role: 'about'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Preferences...',
+				accelerator: 'Cmd+,',
+				click() {
+					sendAction('show-preferences');
+				}
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Log Out',
+				click() {
+					sendAction('log-out');
+				}
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Services',
+				role: 'services',
+				submenu: []
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: `Hide ${appName}`,
+				accelerator: 'Cmd+H',
+				role: 'hide'
+			},
+			{
+				label: 'Hide Others',
+				accelerator: 'Cmd+Shift+H',
+				role: 'hideothers'
+			},
+			{
+				label: 'Show All',
+				role: 'unhide'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: `Quit ${appName}`,
+				accelerator: 'Cmd+Q',
+				click() {
+					app.quit();
+				}
+			}
+		]
+	},
+	{
+		label: 'File',
+		submenu: [
+			{
+				label: 'New Conversation',
+				accelerator: 'CmdOrCtrl+N',
+				click() {
+					sendAction('new-conversation');
+				}
+			}
+		]
+	},
+	{
+		label: 'Edit',
+		submenu: [
+			{
+				label: 'Undo',
+				accelerator: 'CmdOrCtrl+Z',
+				role: 'undo'
+			},
+			{
+				label: 'Redo',
+				accelerator: 'Shift+CmdOrCtrl+Z',
+				role: 'redo'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Cut',
+				accelerator: 'CmdOrCtrl+X',
+				role: 'cut'
+			},
+			{
+				label: 'Copy',
+				accelerator: 'CmdOrCtrl+C',
+				role: 'copy'
+			},
+			{
+				label: 'Paste',
+				accelerator: 'CmdOrCtrl+V',
+				role: 'paste'
+			},
+			{
+				label: 'Select All',
+				accelerator: 'CmdOrCtrl+A',
+				role: 'selectall'
+			}
+		]
+	},
+	{
+		label: 'Window',
+		role: 'window',
+		submenu: [
+			{
+				label: 'Minimize',
+				accelerator: 'CmdOrCtrl+M',
+				role: 'minimize'
+			},
+			{
+				label: 'Close',
+				accelerator: 'CmdOrCtrl+W',
+				role: 'close'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Bring All to Front',
+				role: 'front'
+			}
+		]
+	},
+	{
+		label: 'Help',
+		role: 'help'
+	}
+];
+
+const linuxTpl = [
+	{
+		label: 'File',
+		submenu: [
+			{
+				label: 'New Conversation',
+				accelerator: 'CmdOrCtrl+N',
+				click() {
+					sendAction('new-conversation');
+				}
+			},
+			{
+				label: 'Log Out',
+				click() {
+					sendAction('log-out');
+				}
+			}
+		]
+	},
+	{
+		label: 'Edit',
+		submenu: [
+			{
+				label: 'Undo',
+				accelerator: 'CmdOrCtrl+Z',
+				role: 'undo'
+			},
+			{
+				label: 'Redo',
+				accelerator: 'Shift+CmdOrCtrl+Z',
+				role: 'redo'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Cut',
+				accelerator: 'CmdOrCtrl+X',
+				role: 'cut'
+			},
+			{
+				label: 'Copy',
+				accelerator: 'CmdOrCtrl+C',
+				role: 'copy'
+			},
+			{
+				label: 'Paste',
+				accelerator: 'CmdOrCtrl+V',
+				role: 'paste'
+			},
+			{
+				label: 'Select All',
+				accelerator: 'CmdOrCtrl+A',
+				role: 'selectall'
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Preferences',
+				accelerator: 'CmdOrCtrl+,',
+				click() {
+					sendAction('show-preferences');
+				}
+			}
+		]
+	},
+	{
+		label: 'Help',
+		role: 'help'
+	}
+];
+
+const submenu = [
+	{
+		label: 'Website',
+		click() {
+			shell.openExternal('https://github.com/sindresorhus/caprine');
+		}
+	},
+	{
+		label: 'Report Issue',
+		click() {
+			const body = `
+**Please succinctly describe your issue and steps to reproduce it.**
+
+-
+
+${app.getName()} ${app.getVersion()}
+${process.platform} ${process.arch} ${os.release()}`;
+
+			shell.openExternal(`https://github.com/sindresorhus/caprine/issues/new?body=${encodeURIComponent(body)}`);
+		}
+	},
+	{
+		label: 'About',
+		role: 'about'
+	}
+];
+
 let tpl;
-
 if (process.platform === 'darwin') {
-	tpl = [
-		{
-			label: appName,
-			submenu: [
-				{
-					label: `About ${appName}`,
-					role: 'about'
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Preferences...',
-					accelerator: 'Cmd+,',
-					click() {
-						sendAction('show-preferences');
-					}
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Log Out',
-					click() {
-						sendAction('log-out');
-					}
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Services',
-					role: 'services',
-					submenu: []
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: `Hide ${appName}`,
-					accelerator: 'Cmd+H',
-					role: 'hide'
-				},
-				{
-					label: 'Hide Others',
-					accelerator: 'Cmd+Shift+H',
-					role: 'hideothers'
-				},
-				{
-					label: 'Show All',
-					role: 'unhide'
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: `Quit ${appName}`,
-					accelerator: 'Cmd+Q',
-					click() {
-						app.quit();
-					}
-				}
-			]
-		},
-		{
-			label: 'File',
-			submenu: [
-				{
-					label: 'New Conversation',
-					accelerator: 'CmdOrCtrl+N',
-					click() {
-						sendAction('new-conversation');
-					}
-				}
-			]
-		},
-		{
-			label: 'Edit',
-			submenu: [
-				{
-					label: 'Undo',
-					accelerator: 'CmdOrCtrl+Z',
-					role: 'undo'
-				},
-				{
-					label: 'Redo',
-					accelerator: 'Shift+CmdOrCtrl+Z',
-					role: 'redo'
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Cut',
-					accelerator: 'CmdOrCtrl+X',
-					role: 'cut'
-				},
-				{
-					label: 'Copy',
-					accelerator: 'CmdOrCtrl+C',
-					role: 'copy'
-				},
-				{
-					label: 'Paste',
-					accelerator: 'CmdOrCtrl+V',
-					role: 'paste'
-				},
-				{
-					label: 'Select All',
-					accelerator: 'CmdOrCtrl+A',
-					role: 'selectall'
-				}
-			]
-		},
-		{
-			label: 'Window',
-			role: 'window',
-			submenu: [
-				{
-					label: 'Minimize',
-					accelerator: 'CmdOrCtrl+M',
-					role: 'minimize'
-				},
-				{
-					label: 'Close',
-					accelerator: 'CmdOrCtrl+W',
-					role: 'close'
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Bring All to Front',
-					role: 'front'
-				}
-			]
-		},
-		{
-			label: 'Help',
-			role: 'help',
-			submenu: [
-				{
-					label: 'Website',
-					click() {
-						shell.openExternal('https://github.com/sindresorhus/caprine');
-					}
-				},
-				{
-					label: 'Report Issue',
-					click() {
-						const body = `
-		**Please succinctly describe your issue and steps to reproduce it.**
-
-		-
-
-		${app.getName()} ${app.getVersion()}
-		${process.platform} ${process.arch} ${os.release()}`;
-
-						shell.openExternal(`https://github.com/sindresorhus/caprine/issues/new?body=${encodeURIComponent(body)}`);
-					}
-				}
-			]
-		}
-	];
-} else {
-	tpl = [
-		{
-			label: 'File',
-			submenu: [
-				{
-					label: 'New Conversation',
-					accelerator: 'CmdOrCtrl+N',
-					click() {
-						sendAction('new-conversation');
-					}
-				},
-				{
-					label: 'Log Out',
-					click() {
-						sendAction('log-out');
-					}
-				},
-				{
-					label: `Quit ${appName}`,
-					accelerator: 'CmdOrCtrl+Q',
-					click() {
-						app.quit();
-					}
-				}
-			]
-		},
-		{
-			label: 'Edit',
-			submenu: [
-				{
-					label: 'Undo',
-					accelerator: 'CmdOrCtrl+Z',
-					role: 'undo'
-				},
-				{
-					label: 'Redo',
-					accelerator: 'Shift+CmdOrCtrl+Z',
-					role: 'redo'
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Cut',
-					accelerator: 'CmdOrCtrl+X',
-					role: 'cut'
-				},
-				{
-					label: 'Copy',
-					accelerator: 'CmdOrCtrl+C',
-					role: 'copy'
-				},
-				{
-					label: 'Paste',
-					accelerator: 'CmdOrCtrl+V',
-					role: 'paste'
-				},
-				{
-					label: 'Select All',
-					accelerator: 'CmdOrCtrl+A',
-					role: 'selectall'
-				},
-				{
-					type: 'separator'
-				},
-				{
-					label: 'Preferences',
-					accelerator: 'CmdOrCtrl+,',
-					click() {
-						sendAction('show-preferences');
-					}
-				}
-			]
-		},
-		{
-			label: 'Help',
-			role: 'help',
-			submenu: [
-				{
-					label: 'Website',
-					click() {
-						shell.openExternal('https://github.com/sindresorhus/caprine');
-					}
-				},
-				{
-					label: 'Report Issue',
-					click() {
-						const body = `
-		**Please succinctly describe your issue and steps to reproduce it.**
-
-		-
-
-		${app.getName()} ${app.getVersion()}
-		${process.platform} ${process.arch} ${os.release()}`;
-
-						shell.openExternal(`https://github.com/sindresorhus/caprine/issues/new?body=${encodeURIComponent(body)}`);
-					}
-				},
-				{
-					label: `About ${appName}`,
-					role: 'about'
-				}
-			]
-		}
-	];
+	tpl = darwinTpl;
+} else if (process.platform === 'linux') {
+	tpl = linuxTpl;
 }
+
+tpl[tpl.length - 1].submenu = submenu;
 
 module.exports = Menu.buildFromTemplate(tpl);

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "scripts": {
     "test": "xo",
     "start": "electron .",
-    "build-osx": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media$' --prune --asar --platform=darwin,linux --arch=x64 --icon=media/Icon.icns --app-bundle-id=com.sindresorhus.caprine --sign='Developer ID Application: Sindre Sorhus (YG56YK5RN5)' --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-darwin-x64 && zip -ryXq9 ../Caprine-${npm_package_version}.zip Caprine.app && cd ../Caprine-linux-x64/ && zip -ryq9 Caprine.zip *",
-    "build-linux": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --prune --asar=true --platform=linux --arch=x64 --app-bundle-id=com.sindresorhus.caprine --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-linux-x64/ && zip -ryq9 ../Caprine-linux-\"$npm_package_version\".zip *"
+    "build": "npm run build-osx && npm run build-linux",
+    "build-osx": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media$' --prune --platform=darwin,linux --arch=x64 --icon=media/Icon.icns --app-bundle-id=com.sindresorhus.caprine --sign='Developer ID Application: Sindre Sorhus (YG56YK5RN5)' --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-darwin-x64 && zip -ryXq9 ../Caprine-${npm_package_version}.zip Caprine.app",
+    "build-linux": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media/(?!Icon.png$).*' --prune --platform=linux --arch=x64 --app-bundle-id=com.sindresorhus.caprine --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-linux-x64/ && zip -ryq9 ../Caprine-linux-\"$npm_package_version\".zip *"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "xo",
     "start": "electron .",
     "build": "npm run build-osx && npm run build-linux",
-    "build-osx": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media$' --prune --platform=darwin,linux --arch=x64 --icon=media/Icon.icns --app-bundle-id=com.sindresorhus.caprine --sign='Developer ID Application: Sindre Sorhus (YG56YK5RN5)' --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-darwin-x64 && zip -ryXq9 ../Caprine-${npm_package_version}.zip Caprine.app",
+    "build-osx": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media$' --prune --platform=darwin --arch=x64 --icon=media/Icon.icns --app-bundle-id=com.sindresorhus.caprine --sign='Developer ID Application: Sindre Sorhus (YG56YK5RN5)' --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-darwin-x64 && zip -ryXq9 ../Caprine-${npm_package_version}.zip Caprine.app",
     "build-linux": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media/(?!Icon.png$).*' --prune --platform=linux --arch=x64 --app-bundle-id=com.sindresorhus.caprine --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-linux-x64/ && zip -ryq9 ../Caprine-linux-\"$npm_package_version\".zip *"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "test": "xo",
     "start": "electron .",
-    "build": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media$' --prune --asar --platform=darwin --arch=x64 --icon=media/Icon.icns --app-bundle-id=com.sindresorhus.caprine --sign='Developer ID Application: Sindre Sorhus (YG56YK5RN5)' --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-darwin-x64 && zip -ryXq9 ../Caprine-${npm_package_version}.zip Caprine.app"
+    "build-osx": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --ignore='^/media$' --prune --asar --platform=darwin,linux --arch=x64 --icon=media/Icon.icns --app-bundle-id=com.sindresorhus.caprine --sign='Developer ID Application: Sindre Sorhus (YG56YK5RN5)' --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-darwin-x64 && zip -ryXq9 ../Caprine-${npm_package_version}.zip Caprine.app && cd ../Caprine-linux-x64/ && zip -ryq9 Caprine.zip *",
+    "build-linux": "electron-packager . $npm_package_productName --overwrite --out=dist --ignore='^/dist$' --prune --asar=true --platform=linux --arch=x64 --app-bundle-id=com.sindresorhus.caprine --app-version=$npm_package_version --version=$npm_package_electronVersion && cd dist/Caprine-linux-x64/ && zip -ryq9 ../Caprine-linux-\"$npm_package_version\".zip *"
   },
   "files": [
     "index.js",

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,11 @@
 <br>
 [![](media/screenshot.png)](https://github.com/sindresorhus/caprine/releases/latest)
 
-*Requires OS X 10.8 or newer and Linux. Windows support planned.*
+*Requires OS X 10.8+ and Linux. Windows support planned.*
 
-## Installing on OS X
+## Installing
 
-*To run on Linux, clone the source and follow the ``dev`` instructions below.*
-
-### [Homebrew Cask](http://caskroom.io)
+### OS X: [Homebrew Cask](http://caskroom.io)
 
 ```
 $ brew cask install caprine
@@ -19,7 +17,19 @@ $ brew cask install caprine
 
 ### Manually
 
-[**Download**](https://github.com/sindresorhus/caprine/releases/latest), unzip, and move `Caprine.app` to the `/Applications` directory.
+[**Download**](https://github.com/sindresorhus/caprine/releases/latest) the latest version for your platform. On OS X, unzip and move `Caprine.app` to the `/Applications` directory.
+
+On Linux, unzip to some location. To add a shortcut to the application, create a file in ``~/.local/share/applications`` called ``caprine.desktop`` with the following contents:
+
+```
+[Desktop Entry]
+Name=Caprine
+Exec=/full/path/to/folder/Caprine
+Terminal=false
+Type=Application
+Icon=/full/path/to/folder/resources/app/media/Icon.png
+
+```
 
 
 ## Compact mode

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 *Requires OS X 10.8+ and Linux. Windows support planned.*
 
-## Installing
+## Install
 
 ### OS X: [Homebrew Cask](http://caskroom.io)
 

--- a/readme.md
+++ b/readme.md
@@ -35,11 +35,7 @@ Desktop notifications can be turned on in Preferences.
 
 <div align="center"><img src="media/screenshot-notification.png" width="358"></div>
 
-NOTE: There is a <a href="https://github.com/atom/electron/issues/2294">known bug</a>
-with Electron's handling of desktop notifications on systems running Gnome 3
-that may cause Caprine to crash if notifications are clicked. Until this bug is
-resolved, do not click on notifications if they cause your the app to crash on
-your system.
+NOTE: There is a [known bug](https://github.com/atom/electron/issues/2294) with Electron's handling of desktop notifications on systems running Gnome 3 that may cause Caprine to crash if notifications are clicked. Until this bug is resolved, do not click on notifications if they cause your the app to crash on your system.
 
 ## Dev
 

--- a/readme.md
+++ b/readme.md
@@ -5,10 +5,11 @@
 <br>
 [![](media/screenshot.png)](https://github.com/sindresorhus/caprine/releases/latest)
 
+*Requires OS X 10.8 or newer and Linux. Windows support planned.*
 
-## Install
+## Installing on OS X
 
-*Requires OS X 10.8 or newer. Linux and Windows support planned.*
+*To run on Linux, clone the source and follow the ``dev`` instructions below.*
 
 ### [Homebrew Cask](http://caskroom.io)
 
@@ -34,6 +35,11 @@ Desktop notifications can be turned on in Preferences.
 
 <div align="center"><img src="media/screenshot-notification.png" width="358"></div>
 
+NOTE: There is a <a href="https://github.com/atom/electron/issues/2294">known bug</a>
+with Electron's handling of desktop notifications on systems running Gnome 3
+that may cause Caprine to crash if notifications are clicked. Until this bug is
+resolved, do not click on notifications if they cause your the app to crash on
+your system.
 
 ## Dev
 


### PR DESCRIPTION
Like you noted in #11, this essentially boils down to putting the ``app.dock`` into an if statement. (I don't think there's any Linux equivalent to the dock icon with a number on it, or the bouncing dock icon.)

I also rearranged the menu to be more cross-platformy, since there's no appname menu on most distributions of Linux. (Though there is in Gnome 3, the desktop manager I use, but I couldn't figure out how to add to it from Electron, and Atom doesn't use it either.)

There is a bug with desktop notifications crashing (https://github.com/atom/electron/issues/2294) that seems pretty awful. The issue isn't entirely clear which versions of what it presents itself on, so I added a note to the README about it. The notifications themselves work just fine, and as long as you don't click on them, the system won't crash.

I would be happy to make any changes you need before merging this. I could also test it on a non-Gnome environment.