### PR TITLE
Fix back button position

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -29,7 +29,7 @@ html {
 
 /* hide settings icon */
 ._150g._30yy._2fug._p {
-	display: none;
+	display: none !important;
 }
 
 /* hide title */
@@ -55,6 +55,10 @@ html {
 /* `New messages` popup */
 ._2xhi._5vn4 ._2xhj {
 	display: none;
+}
+
+._30yy._2oc9{
+	margin-left: 65px !important;
 }
 
 @media all and (max-width: 640px) {


### PR DESCRIPTION
Fix issue [#33](https://github.com/sindresorhus/caprine/issues/33) by moving the back button 65px to the right. 
![screen shot 2015-11-24 at 9 29 05 am](https://cloud.githubusercontent.com/assets/329957/11375168/a0fb5df8-928e-11e5-8985-fe780261a612.png)
