### PR TITLE
Add tray for non-darwin platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const ipc = require('electron').ipcMain;
 const app = electron.app;
 const appMenu = require('./menu');
 const storage = require('./storage');
+const createTray = require('./tray');
 
 require('electron-debug')();
 require('electron-dl')();
@@ -71,6 +72,8 @@ app.on('ready', () => {
 	electron.Menu.setApplicationMenu(appMenu);
 
 	mainWindow = createMainWindow();
+
+	createTray(mainWindow);
 
 	const page = mainWindow.webContents;
 

--- a/tray.js
+++ b/tray.js
@@ -1,0 +1,41 @@
+const electron = require('electron');
+const app = electron.app;
+const Menu = electron.Menu;
+const Tray = electron.Tray;
+
+const path = require('path');
+const iconPath = path.join(__dirname, 'media', 'Icon.ico');
+
+module.exports = function (win) {
+	if (process.platform === 'darwin') {
+		return false;
+	}
+
+	const appIcon = new Tray(iconPath);
+	const contextMenu = Menu.buildFromTemplate([
+		{
+			label: 'Show',
+			click() {
+				win.show();
+			}
+		},
+		{
+			label: 'Hide',
+			click() {
+				win.hide();
+			}
+		},
+		{
+			type: 'separator'
+		},
+		{
+			label: 'Quit',
+			click() {
+				app.quit();
+			}
+		}
+	]);
+	appIcon.setToolTip(`${app.getName()}`);
+	appIcon.setContextMenu(contextMenu);
+	return appIcon;
+};


### PR DESCRIPTION
Because Windows or other platforms [doesn't have a Dock feature](https://github.com/atom/electron/blob/master/docs/api/app.md), you can't show or quit Caprine after closing main window. It stays hidden in background forever. So I added a simple Tray for non Darwin platforms.

(Used EditorConfig)