### PR TITLE
Fix icon path on Linux

### DIFF
--- a/tray.js
+++ b/tray.js
@@ -1,7 +1,8 @@
 const path = require('path');
 const electron = require('electron');
 const app = electron.app;
-const iconPath = path.join(__dirname, 'media/Icon.ico');
+const iconExt = (process.platform === 'linux') ? 'png' : 'ico';
+const iconPath = path.join(__dirname, `media/Icon.${iconExt}`);
 
 module.exports = win => {
 	if (process.platform === 'darwin') {


### PR DESCRIPTION
This fixes a crash (#37) that makes Caprine version 0.5.0 unusable on Linux.

@dogancelik, if you could test this to make sure it still works on Windows, that would be greatly appreciated.