### PR TITLE
Add quit option to app menu and open app from tray upon left click

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -189,6 +189,15 @@ const linuxTpl = [
 				click() {
 					sendAction('log-out');
 				}
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Quit',
+				click() {
+					app.quit();
+				}
 			}
 		]
 	},

--- a/tray.js
+++ b/tray.js
@@ -37,6 +37,7 @@ module.exports = win => {
 
 	tray.setToolTip(`${app.getName()}`);
 	tray.setContextMenu(contextMenu);
+	tray.on('clicked', () => win.show());
 
 	return tray;
 };


### PR DESCRIPTION
Since app by default go to tray I think its nice to have quit option in file dropdown.
Also left click on tray does nothing and most users probably expect app to open.