### PR TITLE
Add shortcuts for finding and selecting conversations

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,6 @@
 'use strict';
 const ipc = require('electron').ipcRenderer;
-const listSelector = 'ul[aria-label="Conversation List"] > li';
+const listSelector = 'div[aria-label="Conversations"] > ul > li';
 
 ipc.on('show-preferences', () => {
 	// create the menu for the below
@@ -22,7 +22,7 @@ ipc.on('log-out', () => {
 
 ipc.on('find', () => {
 	document.querySelector('._58al').focus();
-})
+});
 
 ipc.on('next-conversation', () => {
 	const index = getSelectedIndex() + 1;
@@ -40,7 +40,7 @@ function getSelectedIndex() {
 	const selected = document.querySelector('._5l-3._1ht1._1ht2');
 	const list = selected.parentNode;
 
-	return Array.prototype.indexOf.call(list.children, selected);
+	return Array.from(list.children).indexOf(selected);
 }
 
 /* eslint-disable no-native-reassign, no-undef */

--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,6 @@
 'use strict';
 const ipc = require('electron').ipcRenderer;
+const listSelector = 'ul[aria-label="Conversation List"] > li';
 
 ipc.on('show-preferences', () => {
 	// create the menu for the below
@@ -18,6 +19,29 @@ ipc.on('log-out', () => {
 
 	document.querySelector('._54nq._2i-c._558b._2n_z li:last-child a').click();
 });
+
+ipc.on('find', () => {
+	document.querySelector('._58al').focus();
+})
+
+ipc.on('next-conversation', () => {
+	const index = getSelectedIndex() + 1;
+	document.querySelectorAll(listSelector)[index].firstChild.firstChild.click();
+});
+
+ipc.on('previous-conversation', () => {
+	const index = getSelectedIndex() - 1;
+	if (index >= 0) {
+		document.querySelectorAll(listSelector)[index].firstChild.firstChild.click();
+	}
+});
+
+function getSelectedIndex() {
+	const selected = document.querySelector('._5l-3._1ht1._1ht2');
+	const list = selected.parentNode;
+
+	return Array.prototype.indexOf.call(list.children, selected);
+}
 
 /* eslint-disable no-native-reassign, no-undef */
 // Extend and replace the native notifications.

--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,6 @@
 'use strict';
 const ipc = require('electron').ipcRenderer;
-const listSelector = 'div[aria-label="Conversations"] > ul > li';
+const listSelector = 'div[role="navigation"] > ul > li';
 
 ipc.on('show-preferences', () => {
 	// create the menu for the below
@@ -25,22 +25,23 @@ ipc.on('find', () => {
 });
 
 ipc.on('next-conversation', () => {
-	const index = getSelectedIndex() + 1;
+	const index = getNextIndex(true);
 	document.querySelectorAll(listSelector)[index].firstChild.firstChild.click();
 });
 
 ipc.on('previous-conversation', () => {
-	const index = getSelectedIndex() - 1;
-	if (index >= 0) {
-		document.querySelectorAll(listSelector)[index].firstChild.firstChild.click();
-	}
+	const index = getNextIndex(false);
+	document.querySelectorAll(listSelector)[index].firstChild.firstChild.click();
 });
 
-function getSelectedIndex() {
+// return the index for next node if next is true,
+// else returns index for the previous node
+function getNextIndex(next) {
 	const selected = document.querySelector('._5l-3._1ht1._1ht2');
-	const list = selected.parentNode;
+	const list = Array.from(selected.parentNode.children);
+	const index = list.indexOf(selected) + (next ? 1 : -1);
 
-	return Array.from(list.children).indexOf(selected);
+	return (index % list.length + list.length) % list.length;
 }
 
 /* eslint-disable no-native-reassign, no-undef */

--- a/menu.js
+++ b/menu.js
@@ -148,6 +148,40 @@ const darwinTpl = [
 				type: 'separator'
 			},
 			{
+				label: 'Select Next Conversation',
+				accelerator: (() => {
+					if (process.platform === 'darwin') {
+						return 'Cmd+Shift+}';
+					}
+					return 'Ctrl+Tab';
+				})(),
+				click() {
+					sendAction('next-conversation');
+				}
+			},
+			{
+				label: 'Select Previous Conversation',
+				accelerator: (() => {
+					if (process.platform === 'darwin') {
+						return 'Cmd+Shift+{';
+					}
+					return 'Ctrl+Shift+Tab';
+				})(),
+				click() {
+					sendAction('previous-conversation');
+				}
+			},
+			{
+				label: 'Find Conversation',
+				accelerator: 'CmdOrCtrl+F',
+				click() {
+					sendAction('find');
+				}
+			},
+			{
+				type: 'separator'
+			},
+			{
 				label: 'Bring All to Front',
 				role: 'front'
 			},

--- a/menu.js
+++ b/menu.js
@@ -149,24 +149,14 @@ const darwinTpl = [
 			},
 			{
 				label: 'Select Next Conversation',
-				accelerator: (() => {
-					if (process.platform === 'darwin') {
-						return 'Cmd+Shift+}';
-					}
-					return 'Ctrl+Tab';
-				})(),
+				accelerator: 'Ctrl+Tab',
 				click() {
 					sendAction('next-conversation');
 				}
 			},
 			{
 				label: 'Select Previous Conversation',
-				accelerator: (() => {
-					if (process.platform === 'darwin') {
-						return 'Cmd+Shift+{';
-					}
-					return 'Ctrl+Shift+Tab';
-				})(),
+				accelerator: 'Ctrl+Shift+Tab',
 				click() {
 					sendAction('previous-conversation');
 				}


### PR DESCRIPTION
Focus on search bar: Cmd or Ctrl + F

Specific to OSX:
* Next convo: Cmd + Shift + ]
* previous convo: Cmd + Shift + [

On Windows and Linux:
* Next : Ctrl + Tab
* Previous: Ctrl + Shift + Tab

Didn't figure out how to trigger the loading of more conversations when at the bottom of the list.