### PR TITLE
Fix some text color in darkmode

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -241,8 +241,31 @@ html.darkMode ._1ht7 {
 }
 
 /* contact list: search results */
-html.darkMode ._5t4c {
+html.darkMode ._5t4c,
+html.darkMode ._5t4c ._5l37 {
 	background: transparent !important;
+}
+
+/* contact list: search results name */
+html.darkMode ._3q34,
+html.darkMode ._364g {
+	color: rgba(255, 255, 255, 0.7);
+}
+
+/* contact list: search results subname */
+html.darkMode ._3q35 {
+	color: rgba(255, 255, 255, 0.4);
+}
+
+/* contact list: search result label type */
+html.darkMode ._3xcx,
+html.darkMode ._225b {
+	color: rgba(255, 255, 255, 0.4);
+}
+
+/* contact list: searching text */
+html.darkMode ._4g0h {
+	color: rgba(255, 255, 255, 0.4);
 }
 
 /* right sidebar */
@@ -294,7 +317,8 @@ html.darkMode ._4rph ._4rpj {
 	color: rgba(255, 255, 255, 0.7);
 }
 
-/* new conversation contact list: text color */
-html.darkMode ._5t4c ._364g {
-	color: #192633;
+/* new conversation contact list: popup */
+html.darkMode ._2y8_ {
+	background: transparent;
+	border: solid 1px rgba(255, 255, 255, 0.05);
 }

--- a/browser.css
+++ b/browser.css
@@ -158,9 +158,14 @@ html.darkMode ._5742 {
 }
 /* message list: header above (invitation) */
 html.darkMode ._2y8z,
-html.darkMode ._14-7 ._58ah ._58al,
+html.darkMode ._14-7 ._58ah ._58al::-webkit-input-placeholder,
 html.darkMode ._58-3 {
 	color: rgba(255, 255, 255, 0.4);
+}
+
+/* message list: header above (invitation) (typed text) */
+html.darkMode ._14-7 ._58ah ._58al {
+	color: rgba(255, 255, 255, 0.7);
 }
 
 /* messages list: user info (is in contacts) */
@@ -266,6 +271,11 @@ html.darkMode ._3eus {
 	color: rgba(255, 255, 255, 0.4);
 }
 
+/* right sidebar: mute notification setting */
+html.darkMode ._3x6v {
+	color: rgba(255, 255, 255, 0.4);
+}
+
 /* right sidebar: people list */
 html.darkMode ._4_j5 ._5l37 {
 	color: rgba(255, 255, 255, 0.4);
@@ -279,11 +289,12 @@ html.darkMode ._4_j5 ._5l38 {
 
 /* right sidebar: people list item (name) */
 html.darkMode ._364g,
+html.darkMode ._3x6u,
 html.darkMode ._4rph ._4rpj {
 	color: rgba(255, 255, 255, 0.7);
 }
 
 /* new conversation contact list: text color */
-html.darkMode ._5f0v ._364g {
+html.darkMode ._5t4c ._364g {
 	color: #192633;
 }


### PR DESCRIPTION
I changed some CSS in order to fix #55 . Here's what it becomes.

**Before:**
<img width="372" alt="screen shot 2559-02-21 at 11 36 08 pm" src="https://cloud.githubusercontent.com/assets/7040242/13205017/0ad3b532-d910-11e5-808e-b9e4737156aa.png">
<img width="328" alt="screen shot 2559-02-21 at 11 44 41 pm" src="https://cloud.githubusercontent.com/assets/7040242/13205018/0ad88e18-d910-11e5-88f2-5f0936c316e8.png">

**After:**
<img width="420" alt="screen shot 2559-02-21 at 11 36 14 pm" src="https://cloud.githubusercontent.com/assets/7040242/13211590/23c3f82a-d96c-11e5-9498-e8bac5e4c015.png">
<img width="339" alt="screen shot 2559-02-21 at 11 31 47 pm" src="https://cloud.githubusercontent.com/assets/7040242/13211714/7c8533b0-d96d-11e5-9c6f-5dd2a472471f.png">