### PR TITLE
Shortcuts for deleting a conversation.

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -2,13 +2,6 @@ html {
 	overflow: hidden;
 }
 
-/* Add border to focused element in delete menu */
-._3quh._30yy._5ixy:focus {
-	border: 2px solid #0084FF;
-	border-radius: 3px;
-	box-shadow: 0 0 10px #719ECE;
-}
-
 /* window wrapper */
 ._4sp8 {
 	min-width: 0;
@@ -87,6 +80,11 @@ html {
 /* never show outline on clickable elements */
 a, button, *[role="button"] {
 	outline: none !important;
+}
+
+/* Add border to focused element in mute and delete menus */
+._3quh._30yy._5ixy:focus {
+	outline: inherit !important;
 }
 
 

--- a/browser.css
+++ b/browser.css
@@ -2,6 +2,13 @@ html {
 	overflow: hidden;
 }
 
+/* Add border to focused element in delete menu */
+._3quh._30yy._5ixy:focus {
+	border: 2px solid #0084FF;
+	border-radius: 3px;
+	box-shadow: 0 0 10px #719ECE;
+}
+
 /* window wrapper */
 ._4sp8 {
 	min-width: 0;

--- a/browser.css
+++ b/browser.css
@@ -77,14 +77,10 @@ html {
 	}
 }
 
-/* never show outline on clickable elements */
-a, button, *[role="button"] {
+/* don't show outline on clickable elements
+ * except in the delete/mute modal so that we know what we are selecting */
+a, *[role="button"] {
 	outline: none !important;
-}
-
-/* Add border to focused element in mute and delete menus */
-._3quh._30yy._5ixy:focus {
-	outline: inherit !important;
 }
 
 

--- a/browser.css
+++ b/browser.css
@@ -361,8 +361,9 @@ html.darkMode ._4eby {
 /* dialog: title and names */
 html.darkMode ._374c,
 html.darkMode ._4ebz,
-html.darkMode ._2c9i ._19jt {
-	color: rgba(255, 255, 255, 0.7);
+html.darkMode ._2c9i ._19jt,
+html.darkMode .uiInputLabelLabel {
+	color: rgba(255, 255, 255, 0.7) !important;
 }
 
 /* gif and sticker dialog: hide white triangle */
@@ -390,4 +391,21 @@ html.darkMode ._5r86 {
 /* record dialog: time */
 html.darkMode ._3z53 {
 	color: rgba(255, 255, 255, 0.7);
+}
+
+/* Login tile and names */
+html.darkMode ._5hy4,
+html.darkMode ._3403 {
+	color: rgba(255, 255, 255, 0.7) !important;
+}
+
+/* Login inputs */
+html.darkMode ._55r1._5f0v._43di {
+	background: rgba(255, 255, 255, 0.1) !important;
+	color: rgba(255, 255, 255, 0.75);
+}
+
+/* Login button */
+html.darkMode button {
+	background: #192633 !important;
 }

--- a/browser.js
+++ b/browser.js
@@ -5,6 +5,7 @@ const app = electron.remote.app;
 const storage = electron.remote.require('./storage');
 const listSelector = 'div[role="navigation"] > ul > li';
 const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
+const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 
 ipc.on('show-preferences', () => {
 	// create the menu for the below
@@ -32,6 +33,21 @@ ipc.on('find', () => {
 ipc.on('next-conversation', nextConversation);
 
 ipc.on('previous-conversation', previousConversation);
+
+ipc.on('delete-conversation', () => {
+	const index = getIndex();
+	if (index === null) {
+		return;
+	}
+
+	// Open and close the menu for the below
+	const menu = document.querySelectorAll('.uiPopover')[index + 1].firstChild;
+	menu.click();
+	menu.click();
+
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:nth-child(3) a');
+	nodes[nodes.length - 1].click();
+});
 
 ipc.on('dark-mode', toggleDarkMode);
 
@@ -79,10 +95,27 @@ function toggleDarkMode() {
 	setDarkMode();
 }
 
+// returns the index of the selected conversation
+// if no conversation is selected, returns null.
+function getIndex() {
+	const selected = document.querySelector(selectedConversationSelector);
+	if (!selected) {
+		return null;
+	}
+
+	const list = Array.from(selected.parentNode.children);
+
+	return list.indexOf(selected);
+}
+
 // return the index for next node if next is true,
 // else returns index for the previous node
 function getNextIndex(next) {
-	const selected = document.querySelector('._5l-3._1ht1._1ht2');
+	const selected = document.querySelector(selectedConversationSelector);
+	if (!selected) {
+		return 0;
+	}
+
 	const list = Array.from(selected.parentNode.children);
 	const index = list.indexOf(selected) + (next ? 1 : -1);
 

--- a/browser.js
+++ b/browser.js
@@ -10,7 +10,8 @@ ipc.on('show-preferences', () => {
 	// create the menu for the below
 	document.querySelector('._30yy._2fug._p').click();
 
-	document.querySelector('._54nq._2i-c._558b._2n_z li:first-child a').click();
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:first-child a');
+	nodes[nodes.length - 1].click();
 });
 
 ipc.on('new-conversation', () => {

--- a/browser.js
+++ b/browser.js
@@ -35,18 +35,11 @@ ipc.on('next-conversation', nextConversation);
 ipc.on('previous-conversation', previousConversation);
 
 ipc.on('delete-conversation', () => {
-	const index = getIndex();
-	if (index === null) {
-		return;
-	}
+	openConversationModal(3);
+});
 
-	// Open and close the menu for the below
-	const menu = document.querySelectorAll('.uiPopover')[index + 1].firstChild;
-	menu.click();
-	menu.click();
-
-	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:nth-child(3) a');
-	nodes[nodes.length - 1].click();
+ipc.on('mute-conversation', () => {
+	openConversationModal(1);
 });
 
 ipc.on('dark-mode', toggleDarkMode);
@@ -126,6 +119,22 @@ function setZoom(zoomFactor) {
 	const node = document.getElementById('zoomFactor');
 	node.textContent = `${conversationSelector} {zoom: ${zoomFactor} !important}`;
 	storage.set('zoomFactor', zoomFactor);
+}
+
+function openConversationModal(position) {
+	const index = getIndex();
+	if (index === null) {
+		return;
+	}
+
+	// Open and close the menu for the below
+	const menu = document.querySelectorAll('.uiPopover')[index + 1].firstChild;
+	menu.click();
+	menu.click();
+
+	const selector = `._54nq._2i-c._558b._2n_z li:nth-child(${position}) a`;
+	const nodes = document.querySelectorAll(selector);
+	nodes[nodes.length - 1].click();
 }
 
 // link the theme if it was changed while the app was closed

--- a/browser.js
+++ b/browser.js
@@ -23,7 +23,8 @@ ipc.on('log-out', () => {
 	// create the menu for the below
 	document.querySelector('._30yy._2fug._p').click();
 
-	document.querySelector('._54nq._2i-c._558b._2n_z li:last-child a').click();
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:last-child a');
+	nodes[nodes.length - 1].click();
 });
 
 ipc.on('find', () => {

--- a/browser.js
+++ b/browser.js
@@ -35,12 +35,24 @@ ipc.on('next-conversation', nextConversation);
 
 ipc.on('previous-conversation', previousConversation);
 
-ipc.on('delete-conversation', () => {
-	openConversationModal(3);
+ipc.on('mute-conversation', () => {
+	openMuteModal();
 });
 
-ipc.on('mute-conversation', () => {
-	openConversationModal(1);
+ipc.on('delete-conversation', () => {
+	openDeleteModal();
+});
+
+ipc.on('archive-conversation', () => {
+	// Open the modal for the below
+	openDeleteModal();
+
+	const archiveSelector = '._3quh._30yy._2u0._5ixy';
+
+	// Wait for the button to be created
+	window.setTimeout(() => {
+		document.querySelectorAll(archiveSelector)[1].click();
+	}, 10);
 });
 
 ipc.on('dark-mode', toggleDarkMode);
@@ -122,10 +134,10 @@ function setZoom(zoomFactor) {
 	storage.set('zoomFactor', zoomFactor);
 }
 
-function openConversationModal(position) {
+function openConversationMenu() {
 	const index = getIndex();
 	if (index === null) {
-		return;
+		return false;
 	}
 
 	// Open and close the menu for the below
@@ -133,9 +145,30 @@ function openConversationModal(position) {
 	menu.click();
 	menu.click();
 
-	const selector = `._54nq._2i-c._558b._2n_z li:nth-child(${position}) a`;
+	return true;
+}
+
+function openMuteModal() {
+	if (!openConversationMenu()) {
+		return;
+	}
+
+	const selector = '._54nq._2i-c._558b._2n_z li:nth-child(1) a';
 	const nodes = document.querySelectorAll(selector);
 	nodes[nodes.length - 1].click();
+}
+
+function openDeleteModal() {
+	if (!openConversationMenu()) {
+		return;
+	}
+
+	const selector = `._54nq._2i-c._558b._2n_z ul`;
+	const nodes = document.querySelectorAll(selector);
+	const menuList = nodes[nodes.length - 1];
+	const position = menuList.childNodes.length - 3;
+
+	menuList.childNodes[position - 1].firstChild.click();
 }
 
 // link the theme if it was changed while the app was closed

--- a/menu.js
+++ b/menu.js
@@ -149,8 +149,15 @@ const darwinTpl = [
 				type: 'separator'
 			},
 			{
+				label: 'Mute Conversation',
+				accelerator: 'CmdOrCtrl+K',
+				click() {
+					sendAction('mute-conversation');
+				}
+			},
+			{
 				label: 'Delete Conversation',
-				accelerator: 'CmdOrCtrl+X',
+				accelerator: 'CmdOrCtrl+Shift+K',
 				click() {
 					sendAction('delete-conversation');
 				}

--- a/menu.js
+++ b/menu.js
@@ -150,16 +150,23 @@ const darwinTpl = [
 			},
 			{
 				label: 'Mute Conversation',
-				accelerator: 'CmdOrCtrl+K',
+				accelerator: 'CmdOrCtrl+1',
 				click() {
 					sendAction('mute-conversation');
 				}
 			},
 			{
 				label: 'Delete Conversation',
-				accelerator: 'CmdOrCtrl+Shift+K',
+				accelerator: 'CmdOrCtrl+2',
 				click() {
 					sendAction('delete-conversation');
+				}
+			},
+			{
+				label: 'Archive Conversation',
+				accelerator: 'CmdOrCtrl+3',
+				click() {
+					sendAction('archive-conversation');
 				}
 			}
 		]
@@ -279,6 +286,30 @@ const linuxTpl = [
 				accelerator: 'CmdOrCtrl+N',
 				click() {
 					sendAction('new-conversation');
+				}
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Mute Conversation',
+				accelerator: 'CmdOrCtrl+1',
+				click() {
+					sendAction('mute-conversation');
+				}
+			},
+			{
+				label: 'Delete Conversation',
+				accelerator: 'CmdOrCtrl+2',
+				click() {
+					sendAction('delete-conversation');
+				}
+			},
+			{
+				label: 'Archive Conversation',
+				accelerator: 'CmdOrCtrl+3',
+				click() {
+					sendAction('archive-conversation');
 				}
 			},
 			{

--- a/menu.js
+++ b/menu.js
@@ -144,6 +144,16 @@ const darwinTpl = [
 				click() {
 					sendAction('new-conversation');
 				}
+			},
+			{
+				type: 'separator'
+			},
+			{
+				label: 'Delete Conversation',
+				accelerator: 'CmdOrCtrl+X',
+				click() {
+					sendAction('delete-conversation');
+				}
 			}
 		]
 	},


### PR DESCRIPTION
Closes #51 
Closes #84

The works by leveraging the fact that the most recently opened popup get rearranged in the DOM and is placed last in the list.

Once the delete modal is open we can use tab selection to avoid switching to the mouse:
![image](https://cloud.githubusercontent.com/assets/3745612/14786328/5b6d48e4-0acc-11e6-9338-caa87bdef781.png)
![image](https://cloud.githubusercontent.com/assets/3745612/14786336/6a695018-0acc-11e6-9243-08619b0fc3c2.png)

The current shortcut is temporarily set to `CmdOrCtrl+Shift+K` (for Kill?). Didn't want to opt with `Cmd+Backspace` like in iMessages as that would get shadowed by the clear line command in text boxes. So suggestions are welcome.

Also added in a shortcut for mute at `CmdOrCtrl+ K`