### PR TITLE
Bump Electron to 0.37.8 and fix deprecated methods

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,8 +1,9 @@
 'use strict';
 const electron = require('electron');
 const ipc = electron.ipcRenderer;
-const app = electron.remote.app;
 const storage = electron.remote.require('./storage');
+const osxAppearance = require('electron-osx-appearance');
+
 const listSelector = 'div[role="navigation"] > ul > li';
 const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
@@ -57,10 +58,12 @@ ipc.on('archive-conversation', () => {
 
 ipc.on('dark-mode', toggleDarkMode);
 
-app.on('platform-theme-changed', () => {
-	storage.set('darkMode', app.isDarkMode());
-	setDarkMode();
-});
+if (process.platform === 'darwin') {
+	osxAppearance.onDarkModeChanged(() => {
+		storage.set('darkMode', osxAppearance.isDarkMode());
+		setDarkMode();
+	});
+}
 
 ipc.on('zoom-reset', () => {
 	setZoom(1.0);
@@ -173,7 +176,7 @@ function openDeleteModal() {
 
 // link the theme if it was changed while the app was closed
 if (process.platform === 'darwin') {
-	storage.set('darkMode', app.isDarkMode());
+	storage.set('darkMode', osxAppearance.isDarkMode());
 }
 
 // activate Dark Mode if it was set before quitting

--- a/menu.js
+++ b/menu.js
@@ -26,7 +26,7 @@ const viewSubmenu = [
 	},
 	{
 		label: 'Increase Text Size',
-		accelerator: 'CmdOrCtrl+=',
+		accelerator: 'CmdOrCtrl+Plus',
 		click() {
 			sendAction('zoom-in');
 		}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     {
       "name": "Daniel Pham",
       "email": "pham.dany@gmail.com",
-      "url": "phamdaniel.github.io"
+      "url": "danhp.github.io"
     }
   ],
   "scripts": {
@@ -49,11 +49,12 @@
   ],
   "dependencies": {
     "electron-debug": "^0.7.0",
-    "electron-dl": "^0.2.0"
+    "electron-dl": "^0.2.0",
+    "electron-osx-appearance": "^0.1.0"
   },
   "devDependencies": {
     "electron-packager": "^7.0.0",
-    "electron-prebuilt": "^0.37.7",
+    "electron-prebuilt": "^0.37.8",
     "xo": "*"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "electron-debug": "^0.7.0",
     "electron-dl": "^0.2.0",
-    "electron-osx-appearance": "^0.1.0"
+    "electron-osx-appearance": "^0.1.1"
   },
   "devDependencies": {
     "electron-packager": "^7.0.0",


### PR DESCRIPTION
Bump to 0.37.8 to fix #83 
Also use https://github.com/danhp/electron-osx-appearance as `app.isDarkMode()` and `platform-theme-changed` event got deprecated. Ref https://github.com/electron/electron/pull/5282