### PR TITLE
Add option to auto hide the menu bar

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ function createMainWindow() {
 		minWidth: 400,
 		minHeight: 200,
 		titleBarStyle: 'hidden-inset',
+		autoHideMenuBar: true,
 		webPreferences: {
 			// fails without this because of CommonJS script detection
 			nodeIntegration: false,


### PR DESCRIPTION
This is blatantly stolen from Slack's Windows app.

Before:
![dirty](https://cloud.githubusercontent.com/assets/3745612/15290878/35d3f58c-1b49-11e6-9ff5-545c3caedf4d.jpg)
 
With the option turned on:
![clean](https://cloud.githubusercontent.com/assets/3745612/15290883/3e7d7b54-1b49-11e6-950b-8609b0922c7b.png)

It follows native behavior in that if hidden, hitting `Alt` will show the menu 