### PR TITLE
Fixed dark mode overriding code snippet color

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -20,6 +20,11 @@ html.dark-mode ._o46:not(._nd_) ._hh7 {
 	color: rgba(255, 255, 255, 0.7);
 }
 
+/* fix dark mode overriding colors for code snippets */
+html.dark-mode ._wu0 {
+	color: black;
+}
+
 /* message list: link in your message bubble */
 html.dark-mode ._o46:not(._nd_) ._hh7 a {
 	color: rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
This should fix #105. I think the issue was some transparency affecting un-styled text in code snippets.

<img width="479" alt="screen shot 2016-06-02 at 2 29 52 pm" src="https://cloud.githubusercontent.com/assets/6325382/15756308/b08f8ef2-28ce-11e6-8a6e-c663c322c3c0.png">
<img width="481" alt="screen shot 2016-06-02 at 2 30 06 pm" src="https://cloud.githubusercontent.com/assets/6325382/15756314/b30376bc-28ce-11e6-9d27-7efa609c5995.png">
