### PR TITLE
Bounce the dock icon when receiving a new message

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,15 +29,13 @@ if (isAlreadyRunning) {
 	app.quit();
 }
 
-function updateBadge(title) {
-	// ignore `Sindre messaged you` blinking
-	if (title.indexOf('Messenger') === -1) {
-		return;
-	}
-
+function getMessageCount(title) {
 	let messageCount = (/\(([0-9]+)\)/).exec(title);
 	messageCount = messageCount ? Number(messageCount[1]) : 0;
+	return messageCount;
+}
 
+function updateBadge(messageCount) {
 	if (process.platform === 'darwin' || process.platform === 'linux') {
 		app.setBadgeCount(messageCount);
 	}
@@ -92,8 +90,15 @@ function createMainWindow() {
 
 	win.on('page-title-updated', (e, title) => {
 		e.preventDefault();
-		updateBadge(title);
-		app.dock.bounce()
+		// ignore `Sindre messaged you` blinking
+		if (title.indexOf('Messenger') === -1) {
+			return;
+		}
+		const messageCount = getMessageCount(title);
+		updateBadge(messageCount);
+		if (messageCount !== 0) {
+			app.dock.bounce();
+		}
 	});
 
 	return win;

--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ function createMainWindow() {
 	win.on('page-title-updated', (e, title) => {
 		e.preventDefault();
 		updateBadge(title);
+		app.dock.bounce()
 	});
 
 	return win;


### PR DESCRIPTION
This pull request would make the dock icon continuously bounce when receiving a new message until Caprine window is focus.

This would resolve @mgol 's #111 

However, I think someone might want to turn this off. So may be this should be an option?

And is it more appropriate to bounce only once rather than bounce continuously? I'm still not sure about this.

I'd love to hear your thoughts! 😃 
