### PR TITLE
Add CLI flag to start app minimized

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,10 +109,9 @@ app.on('ready', () => {
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'dark-mode.css'), 'utf8'));
 
-		if (process.argv.indexOf("-m") > -1){
+		if (process.argv.indexOf('-m') > -1) {
 			mainWindow.minimize();
-		}
-		else {
+		} else {
 			mainWindow.show();
 		}
 	});

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ app.on('ready', () => {
 
 	const page = mainWindow.webContents;
 
-	let argv = require('minimist')(process.argv.slice(1));
+	const argv = require('minimist')(process.argv.slice(1));
 
 	page.on('dom-ready', () => {
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ app.on('ready', () => {
 
 	const page = mainWindow.webContents;
 
-	var argv = require('minimist')(process.argv.slice(1));
+	let argv = require('minimist')(process.argv.slice(1));
 
 	page.on('dom-ready', () => {
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));

--- a/index.js
+++ b/index.js
@@ -108,7 +108,13 @@ app.on('ready', () => {
 	page.on('dom-ready', () => {
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'dark-mode.css'), 'utf8'));
-		mainWindow.show();
+
+		if (process.argv.indexOf("-m") > -1){
+			mainWindow.minimize();
+		}
+		else {
+			mainWindow.show();
+		}
 	});
 
 	page.on('new-window', (e, url) => {

--- a/index.js
+++ b/index.js
@@ -105,11 +105,13 @@ app.on('ready', () => {
 
 	const page = mainWindow.webContents;
 
+	var argv = require('minimist')(process.argv.slice(1));
+
 	page.on('dom-ready', () => {
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'browser.css'), 'utf8'));
 		page.insertCSS(fs.readFileSync(path.join(__dirname, 'dark-mode.css'), 'utf8'));
 
-		if (process.argv.indexOf('-m') > -1) {
+		if (argv.minimize) {
 			mainWindow.minimize();
 		} else {
 			mainWindow.show();

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@
 
 When closing the window, the app will continue running in the background, in the dock on macOS and the tray on Linux/Windows. Right-click the dock/tray icon and choose `Quit` to completely quit the app. On macOS, click the dock icon to show the window. On Linux, right-click the tray icon and choose `Toggle` to toggle the window. On Windows, click the tray icon to toggle the window.
 
+If you wish to start Caprine minimized simply add the --minimize flag to the app on startup.
 
 ### Dark mode
 


### PR DESCRIPTION
Fixes #64 
Added a support for a simple "-m" flag that will cause the app to start up minimized. 
I only tested this on Arch Linux. It should work for all linux distributions, and in theory on MacOS. 

Since there are no other command line options I wasn't sure if we should have a help/usage message or not