### PR TITLE
Update package.json to include dependency for minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "electron-config": "^0.2.1",
     "electron-context-menu": "^0.6.0",
     "electron-debug": "^1.0.0",
-    "electron-dl": "^1.0.0"
+    "electron-dl": "^1.0.0",
+    "minimist": "^0.0.8"
   },
   "devDependencies": {
     "electron": "^1.4.0",


### PR DESCRIPTION
building the app currently succeeds, but fails to run with an error message about needing minimist@^0.0.8. It just needed it to be listed in package.json as a dependency. Very small fix.
