### PR TITLE
Add support for showing/hiding the sidebar

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -85,6 +85,18 @@ ipc.on('zoom-out', () => {
 	}
 });
 
+ipc.on('toggle-sidebar', () => {
+	const root = document.querySelectorAll('[data-reactroot]')[0];
+
+	// Hiding the sidebar completely removes it on wide windows, but leaves it
+	// empty on smaller windows
+	const sidebar = root.firstElementChild.firstElementChild;
+	const display = sidebar.style.display;
+	const shouldHide = (display === '');
+	const newDisplay = shouldHide ? 'none' : '';
+	sidebar.style.display = newDisplay;
+});
+
 function nextConversation() {
 	const index = getNextIndex(true);
 	selectConversation(index);

--- a/menu.js
+++ b/menu.js
@@ -21,6 +21,16 @@ function sendAction(action) {
 
 const viewSubmenu = [
 	{
+		label: 'Toggle Sidebar Avatars',
+		accelerator: 'CmdOrCtrl+Shift+H',
+		click() {
+			sendAction('toggle-sidebar');
+		}
+	},
+	{
+		type: 'separator'
+	},
+	{
 		label: 'Reset Text Size',
 		accelerator: 'CmdOrCtrl+0',
 		click() {


### PR DESCRIPTION
Hey there, I wanted to be able to both focus on working on a bot, and to be able to easily take [screenshots](https://github.com/artsy/Mitosis/issues/8) of my work, so I added the ability to toggle the sidebar. 

It's your call whether this feature is worth it for the general public, but I thought it would be at least worth presenting as an option for you.

wide mode, no sidebar:
![screen shot 2016-11-15 at 10 08 55](https://cloud.githubusercontent.com/assets/49038/20301580/cbc3cef2-ab1b-11e6-94fb-afc162ff3500.png)

constrained width, invisible avatars
![screen shot 2016-11-15 at 10 11 44](https://cloud.githubusercontent.com/assets/49038/20301634/fbfa4b32-ab1b-11e6-8dcc-058bc6e35553.png)

( I couldn't find a way to override the injected stylesheet's `left: "74px !important"` - didn't matter too much to me for my purposes )