### PR TITLE
Disable forced greyscale font antialiasing

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -3,7 +3,6 @@ html {
 }
 
 /* Bind the toolbar as the window's draggable region */
-
 ._36ic._5l-3,
 ._5742 {
 	-webkit-app-region: drag;
@@ -64,6 +63,7 @@ html {
 ._fl2 {
 	padding: 3px 8px !important;
 }
+
 /* Adjust `To` field for narrower titlebar */
 ._2y8y {
 	min-height: 40px !important;

--- a/browser.css
+++ b/browser.css
@@ -23,6 +23,11 @@ html {
 	display: none;
 }
 
+/* "Keep the conversation going" bar */
+._s15 {
+	display: none !important;
+}
+
 /* right-column */
 ._1q5- {
 	border-left: 1px solid rgba(0, 0, 0, .10) !important;

--- a/browser.css
+++ b/browser.css
@@ -2,12 +2,6 @@ html {
 	overflow: hidden;
 }
 
-body {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
-	text-rendering: optimizeLegibility;
-	font-feature-settings: "liga", "clig", "dlig", "kern";
-}
-
 /* Bind the toolbar as the window's draggable region */
 
 ._36ic._5l-3,

--- a/browser.css
+++ b/browser.css
@@ -3,19 +3,8 @@ html {
 }
 
 body {
-	font-family:	-apple-system,
-			BlinkMacSystemFont, 
-			"Segoe UI", 
-			Roboto, 
-			Oxygen-Sans, 
-			Ubuntu, 
-			Cantarell, 
-			"Helvetica Neue",
-			sans-serif,
-			"Apple Color Emoji",
-			"Segoe UI Emoji",
-			"Segoe UI Symbol" !important;
-	text-rendering: optimizeLegibility !important;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
+	text-rendering: optimizeLegibility;
 	font-feature-settings: "liga", "clig", "dlig", "kern";
 }
 
@@ -23,6 +12,11 @@ body {
 ._36ic._5l-3,
 ._5742 {
 	-webkit-app-region: drag;
+}
+
+/* add back subpixel antialiasing */
+._2sdm {
+	-webkit-font-smoothing: initial;
 }
 
 /* window wrapper */
@@ -71,6 +65,7 @@ body {
 	height: 40px !important;
 	padding: 4px !important;
 }
+
 ._fl2 {
 	padding: 3px 8px !important;
 }

--- a/browser.css
+++ b/browser.css
@@ -59,11 +59,9 @@ html {
 	height: 40px !important;
 	padding: 4px !important;
 }
-
 ._fl2 {
 	padding: 3px 8px !important;
 }
-
 /* Adjust `To` field for narrower titlebar */
 ._2y8y {
 	min-height: 40px !important;

--- a/browser.css
+++ b/browser.css
@@ -2,15 +2,33 @@ html {
 	overflow: hidden;
 }
 
-/* Bind the toolbar as the window's draggable region */
-._36ic._5l-3,
-._5742 {
-	-webkit-app-region: drag;
+/* Add OS specific fonts */
+body {
+	font-family: -apple-system,
+			BlinkMacSystemFont,
+			'Segoe UI',
+			Roboto,
+			Oxygen-Sans,
+			Ubuntu,
+			Cantarell,
+			'Helvetica Neue',
+			sans-serif,
+			'Apple Color Emoji',
+			'Segoe UI Emoji',
+			'Segoe UI Symbol' !important;
+	text-rendering: optimizeLegibility !important;
+	font-feature-settings: 'liga', 'clig', 'dlig', 'kern';
 }
 
 /* Add back subpixel antialiasing */
 ._2sdm {
 	-webkit-font-smoothing: initial;
+}
+
+/* Bind the toolbar as the window's draggable region */
+._36ic._5l-3,
+._5742 {
+	-webkit-app-region: drag;
 }
 
 /* Window wrapper */


### PR DESCRIPTION
The white font on colored backgrounds ends up being too thin on non-retina displays. Adding <code>&#8209;webkit&#8209;font&#8209;smoothing: initial;</code> fixes this by reverting it to the default behaviour.

Blink on retina displays will use greyscale rendering either way — this change does not affect it. This rule has no effect on Windows systems.