### PR TITLE
Fix name and link for Homebrew Cask in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 
 [**Download**](https://github.com/sindresorhus/caprine/releases/latest) the `.dmg` file.
 
-Or with [Homebrew-Cask](https://caskroom.github.io): `$ brew cask install caprine`
+Or with [Homebrew Cask](https://caskroom.github.io): `$ brew cask install caprine`
 
 ### Linux
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 
 [**Download**](https://github.com/sindresorhus/caprine/releases/latest) the `.dmg` file.
 
-Or with [Cask](http://caskroom.io): `$ brew cask install caprine`
+Or with [Homebrew-Cask](https://caskroom.github.io): `$ brew cask install caprine`
 
 ### Linux
 


### PR DESCRIPTION
We got rid of the old domain because it mostly caused issues.