### PR TITLE
Improve highlight for selected conversation

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -126,7 +126,7 @@ a,
 ._1ht1._1ht2 {
 	background-color: rgba(0, 132, 255, 0.3) !important;
 }
-/* Contact list: latest message, under conact name*/
+/* Contact list: latest message, under contact name */
 ._1ht1 ._1htf {
 	color: rgba(0, 0, 0, 0.7);
 }

--- a/browser.css
+++ b/browser.css
@@ -127,7 +127,3 @@ a,
 	background-color: rgba(0, 132, 255, 0.3) !important;
 
 }
-/* Contact list: selected person, latest message */
-._1ht1._1ht2 ._1htf {
-	color: rgba(0, 0, 0, 0.4);
-}

--- a/browser.css
+++ b/browser.css
@@ -124,7 +124,7 @@ a,
 
 /* Contact list: person (selected) */
 ._1ht1._1ht2 {
-	background-color: rgba(0, 132, 255, 0.8) !important;
+	background-color: rgba(0, 132, 255, 0.3) !important;
 
 }
 /* Contact list: selected person, latest message */

--- a/browser.css
+++ b/browser.css
@@ -125,5 +125,8 @@ a,
 /* Contact list: person (selected) */
 ._1ht1._1ht2 {
 	background-color: rgba(0, 132, 255, 0.3) !important;
-
+}
+/* Contact list: latest message, under conact name*/
+._1ht1 ._1htf {
+	color: rgba(0, 0, 0, 0.7);
 }

--- a/browser.css
+++ b/browser.css
@@ -121,3 +121,13 @@ a,
 ._4eby {
 	border-radius: 2px !important;
 }
+
+/* Contact list: person (selected) */
+._1ht1._1ht2 {
+	background-color: rgba(0, 132, 255, 0.8) !important;
+
+}
+/* Contact list: selected person, latest message */
+._1ht1._1ht2 ._1htf {
+	color: rgba(0, 0, 0, 0.4);
+}

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -162,7 +162,7 @@ html.dark-mode ._1ht7 {
 }
 /* Contact list: timestamp (selected) */
 html.dark-mode ._1ht2 ._1ht7 {
-	color: rgba(255, 255, 255, 0.7);
+	color: rgba(255, 255, 255, 0.5);
 }
 /* Contact list: timestamp (unread) */
 html.dark-mode ._1ht3 ._1ht7 {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -138,7 +138,7 @@ html.dark-mode ._1ht1 {
 
 /* Contact list: person (selected) */
 html.dark-mode ._1ht1._1ht2 {
-	background-color: rgba(0, 132, 255, 0.6) !important;
+	background: linear-gradient(-45deg, #1871DC, #1870DB) !important
 }
 
 /* Contact list: person container */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -138,7 +138,7 @@ html.dark-mode ._1ht1 {
 
 /* Contact list: person (selected) */
 html.dark-mode ._1ht1._1ht2 {
-	background: rgba(255, 255, 255, 0.03) !important;
+	background-color: rgba(0, 132, 255, 0.6) !important;
 }
 
 /* Contact list: person container */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -138,7 +138,7 @@ html.dark-mode ._1ht1 {
 
 /* Contact list: person (selected) */
 html.dark-mode ._1ht1._1ht2 {
-	background: linear-gradient(-45deg, #1871DC, #1870DB) !important
+	background: linear-gradient(180deg, #1871DC, #1870DB) !important;
 }
 
 /* Contact list: person container */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -160,7 +160,10 @@ html.dark-mode ._1htf {
 html.dark-mode ._1ht7 {
 	color: rgba(255, 255, 255, 0.2);
 }
-
+/* Contact list: timestamp (selected) */
+html.dark-mode ._1ht2 ._1ht7 {
+	color: rgba(255, 255, 255, 0.7);
+}
 /* Contact list: timestamp (unread) */
 html.dark-mode ._1ht3 ._1ht7 {
 	color: rgba(0, 132, 255, 0.7)


### PR DESCRIPTION
Fixes #138 

- Used the blue from message bubbles with different opacity in
dark/light modes.
- Slight tweaked the color of the latest message subtitle, so it would be easier to read in light mode.