### PR TITLE
Force the Window to be resizable for all platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,8 @@ function createMainWindow() {
 		}
 	});
 
+	win.setResizable(true);
+
 	if (process.platform === 'darwin') {
 		win.setSheetOffset(40);
 	}


### PR DESCRIPTION
This implements #178.

On Windows 10 the window couldn't be resized, I added `win.setResizable(true)` into the window creation function. Sadly there doesn't seem to be an option we can pass into the constructor so this had to be done after.

As this issue has only be found on Windows 10, it could be wrapped in a platform check but as I understand, we want to ensure it can be resized on all platforms anyway.