### PR TITLE
Remove greyscale font antialiasing

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -20,6 +20,12 @@ body {
 	font-feature-settings: 'liga', 'clig', 'kern';
 }
 
+/* Add back subpixel antialiasing */
+._2sdm {
+	-webkit-font-smoothing: initial;
+}
+
+
 /* Bind the toolbar as the window's draggable region */
 ._36ic._5l-3,
 ._5742 {


### PR DESCRIPTION
The white font weight on colored backgrounds is way too light on non-retina displays:
![image](https://cloud.githubusercontent.com/assets/2827047/24857840/f9c90cd6-1de9-11e7-8390-9856432954e8.png)

With subpixel aa:
![image](https://cloud.githubusercontent.com/assets/2827047/24857875/15d75856-1dea-11e7-8101-e333c80f9d65.png)

For retina displays, the `initial` property defaults to `greyscale` on Blink anyway.
