### PR TITLE
readme.md: add hyphen in homebrew-cask

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 
 [**Download**](https://github.com/sindresorhus/caprine/releases/latest) the `.dmg` file.
 
-Or with [Cask](http://caskroom.io): `$ brew cask install caprine`
+Or with [Homebrew Cask](https://caskroom.github.io): `$ brew cask install caprine`
 
 ### Linux
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 
 [**Download**](https://github.com/sindresorhus/caprine/releases/latest) the `.dmg` file.
 
-Or with [Homebrew Cask](https://caskroom.github.io): `$ brew cask install caprine`
+Or with [Homebrew-Cask](https://caskroom.github.io): `$ brew cask install caprine`
 
 ### Linux
 


### PR DESCRIPTION
The correct name is with the hyphen. Source: I’m the longest active maintainer of Homebrew-Cask.

The website version is wrong, the Github page is the canonical one. It has an hyphen.