### PR TITLE
Fix scrolling issue with "Edit Nicknames" dialog

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -130,3 +130,9 @@ a,
 ._1ht1 ._1htf {
 	color: rgba(0, 0, 0, 0.7);
 }
+
+/* Allow scrolling of "Edit Nicknames" dialog */
+._4h9n ._4h9o {
+	max-height: 100% !important;
+	height: 280px;
+}


### PR DESCRIPTION
Found an issue with the "Edit Nicknames" dialog when there are multiple users in a group chat