### PR TITLE
Fix disappearing shadow on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,6 @@ function createMainWindow() {
 		titleBarStyle: 'hidden-inset',
 		autoHideMenuBar: true,
 		darkTheme: isDarkMode, // GTK+3
-		transparent: process.platform === 'darwin',
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nodeIntegration: false,


### PR DESCRIPTION
Transparent windows aren't needed to get vibrancy to work. Windows must simply not have any backgrounds to them.

Previous change:
![image](https://cloud.githubusercontent.com/assets/3745612/25582807/0b8e4f52-2e5d-11e7-929f-d889f75fd701.png)


Fixes #183 

