### PR TITLE
Add option to disable seen/typing indicators

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,6 +11,10 @@ module.exports = new Config({
 			height: 600
 		},
 		alwaysOnTop: false,
-		bounceDockOnMessage: false
+		bounceDockOnMessage: false,
+		block: {
+			chatSeen: false,
+			typingIndicator: false
+		}
 	}
 });

--- a/index.js
+++ b/index.js
@@ -84,6 +84,20 @@ function enableHiresResources() {
 	});
 }
 
+function setUpPrivacyBlocking() {
+	const ses = electron.session.defaultSession;
+	const filter = {urls: ['*://*.messenger.com/*typ.php*', '*://*.messenger.com/*change_read_status.php*']};
+	ses.webRequest.onBeforeRequest(filter, (details, callback) => {
+		let blocking = false;
+		if (details.url.includes('typ.php')) {
+			blocking = config.get('block.typingIndicator');
+		} else {
+			blocking = config.get('block.chatSeen');
+		}
+		callback({cancel: blocking});
+	});
+}
+
 function createMainWindow() {
 	const lastWindowState = config.get('lastWindowState');
 	const isDarkMode = config.get('darkMode');
@@ -109,6 +123,8 @@ function createMainWindow() {
 			plugins: true
 		}
 	});
+
+	setUpPrivacyBlocking();
 
 	if (process.platform === 'darwin') {
 		win.setSheetOffset(40);

--- a/menu.js
+++ b/menu.js
@@ -130,6 +130,22 @@ const darwinTpl = [
 				}
 			},
 			{
+				type: 'checkbox',
+				label: 'Block Seen Indicator',
+				checked: config.get('block.chatSeen'),
+				click(item) {
+					config.set('block.chatSeen', item.checked);
+				}
+			},
+			{
+				type: 'checkbox',
+				label: 'Block Typing Indicator',
+				checked: config.get('block.typingIndicator'),
+				click(item) {
+					config.set('block.typingIndicator', item.checked);
+				}
+			},
+			{
 				label: 'Preferences...',
 				accelerator: 'Cmd+,',
 				click() {
@@ -311,6 +327,25 @@ const otherTpl = [
 				accelerator: 'Ctrl+Shift+D',
 				click() {
 					sendAction('delete-conversation');
+				}
+			},
+			{
+				type: 'separator'
+			},
+			{
+				type: 'checkbox',
+				label: 'Block Seen Indicator',
+				checked: config.get('block.chatSeen'),
+				click(item) {
+					config.set('block.chatSeen', item.checked);
+				}
+			},
+			{
+				type: 'checkbox',
+				label: 'Block Typing Indicator',
+				checked: config.get('block.typingIndicator'),
+				click(item) {
+					config.set('block.typingIndicator', item.checked);
 				}
 			},
 			{

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,10 @@ Desktop notifications can be turned on in Preferences.
 
 You can toggle whether Caprine stays on top of other windows in the `Window`/`View` menu or with <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>t</kbd>.
 
+### Hide last seen / typing indicator
+
+You can choose to prevent people from knowing when you've seen a message or are currently typing. Both options are available under the `Caprine`/`File` menu.
+
 ### Keyboard shortcuts
 
 Description            | Keys


### PR DESCRIPTION
Add options to independently disable read receipts & typing indicators.

Fixes #186 .