### PR TITLE
Add unread count and taskbar overlay icon for Windows

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -80,13 +80,8 @@ function renderOverlayIcon(messageCount) {
 	ctx.fill();
 	ctx.textAlign = 'center';
 	ctx.fillStyle = 'white';
-	if (messageCount > 99) {
-		ctx.font = '90px sans-serif';
-		ctx.fillText('99', 64, 96);
-	} else {
-		ctx.font = '90px sans-serif';
-		ctx.fillText(String(messageCount), 64, 96);
-	}
+	ctx.font = '90px sans-serif';
+	ctx.fillText(String(Math.min(99, messageCount)), 64, 96);
 	return canvas;
 }
 

--- a/browser.js
+++ b/browser.js
@@ -68,6 +68,31 @@ function setVibrancy() {
 	document.documentElement.style.backgroundColor = 'transparent';
 }
 
+function renderOverlayIcon(messageCount) {
+	const canvas = document.createElement('canvas');
+	canvas.height = 128;
+	canvas.width = 128;
+	canvas.style.letterSpacing = '-5px';
+	const ctx = canvas.getContext('2d');
+	ctx.fillStyle = '#f42020';
+	ctx.beginPath();
+	ctx.ellipse(64, 64, 64, 64, 0, 0, 2 * Math.PI);
+	ctx.fill();
+	ctx.textAlign = 'center';
+	ctx.fillStyle = 'white';
+	if (messageCount > 99) {
+		ctx.font = '96px sans-serif';
+		ctx.fillText('99', 64, 96);
+	} else if (messageCount > 9) {
+		ctx.font = '96px sans-serif';
+		ctx.fillText(String(messageCount), 64, 96);
+	} else {
+		ctx.font = '102px sans-serif';
+		ctx.fillText(String(messageCount), 64, 98);
+	}
+	return canvas;
+}
+
 ipc.on('toggle-dark-mode', () => {
 	config.set('darkMode', !config.get('darkMode'));
 	setDarkMode();
@@ -76,6 +101,10 @@ ipc.on('toggle-dark-mode', () => {
 ipc.on('toggle-vibrancy', () => {
 	config.set('vibrancy', !config.get('vibrancy'));
 	setVibrancy();
+});
+
+ipc.on('render-overlay-icon', (event, messageCount) => {
+	ipc.send('update-overlay-icon', renderOverlayIcon(messageCount).toDataURL(), String(messageCount));
 });
 
 ipc.on('zoom-reset', () => {

--- a/browser.js
+++ b/browser.js
@@ -81,14 +81,11 @@ function renderOverlayIcon(messageCount) {
 	ctx.textAlign = 'center';
 	ctx.fillStyle = 'white';
 	if (messageCount > 99) {
-		ctx.font = '96px sans-serif';
+		ctx.font = '90px sans-serif';
 		ctx.fillText('99', 64, 96);
-	} else if (messageCount > 9) {
-		ctx.font = '96px sans-serif';
-		ctx.fillText(String(messageCount), 64, 96);
 	} else {
-		ctx.font = '102px sans-serif';
-		ctx.fillText(String(messageCount), 64, 98);
+		ctx.font = '90px sans-serif';
+		ctx.fillText(String(messageCount), 64, 96);
 	}
 	return canvas;
 }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,21 @@ function updateBadge(title) {
 	if (process.platform === 'linux' || process.platform === 'win32') {
 		tray.setBadge(messageCount);
 	}
+
+	if (process.platform === 'win32') {
+		if (messageCount === 0) {
+			mainWindow.setOverlayIcon(null, '');
+		} else {
+			// Delegate drawing of overlay icon to renderer process
+			mainWindow.webContents.send('render-overlay-icon', messageCount);
+		}
+	}
 }
+
+ipcMain.on('update-overlay-icon', (event, data, text) => {
+	const img = electron.nativeImage.createFromDataURL(data);
+	mainWindow.setOverlayIcon(img, text);
+});
 
 function enableHiresResources() {
 	const scaleFactor = Math.max(...electron.screen.getAllDisplays().map(x => x.scaleFactor));

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ Or with [Homebrew-Cask](https://caskroom.github.io): `$ brew cask install caprin
 
 [**Download**](https://github.com/sindresorhus/caprine/releases/latest) the `.exe` file.
 
+*For taskbar notification badges to work on Windows 10, you'll need to [enable it in Taskbar Settings](https://www.tenforums.com/tutorials/48186-taskbar-buttons-hide-show-badges-windows-10-a.html).*
 
 ## Features
 


### PR DESCRIPTION
We can make use of overlay icons to display unread thread count in Windows, similar to how badge counts work in macOS & Unity. 
![image](https://cloud.githubusercontent.com/assets/6357330/25594744/d4473272-2eb9-11e7-8e40-9c50cab1f94e.png)

Since tray icons are hidden by default, this also eliminates the need for the user to pin the tray icon.