### PR TITLE
Fix sending and receiving voice/video calls from within Caprine

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,9 +201,11 @@ app.on('ready', () => {
 
 	webContents.on('new-window', (e, url, frameName, disposition, options) => {
 		e.preventDefault();
-		if (url === 'about:blank') {  // Voice/video call popup
-			options.show = true;
-			e.newGuest = new electron.BrowserWindow(options);
+		if (url === 'about:blank') {
+			if (frameName === 'Video Call') {  // Voice/video call popup
+				options.show = true;
+				e.newGuest = new electron.BrowserWindow(options);
+			}
 		} else {
 			electron.shell.openExternal(url);
 		}

--- a/index.js
+++ b/index.js
@@ -199,9 +199,14 @@ app.on('ready', () => {
 		}
 	});
 
-	webContents.on('new-window', (e, url) => {
+	webContents.on('new-window', (e, url, frameName, disposition, options) => {
 		e.preventDefault();
-		electron.shell.openExternal(url);
+		if (url === 'about:blank') {  // Voice/video call popup
+			options.show = true;
+			e.newGuest = new electron.BrowserWindow(options);
+		} else {
+			electron.shell.openExternal(url);
+		}
 	});
 });
 

--- a/index.js
+++ b/index.js
@@ -204,6 +204,7 @@ app.on('ready', () => {
 		if (url === 'about:blank') {
 			if (frameName === 'Video Call') {  // Voice/video call popup
 				options.show = true;
+				options.titleBarStyle = 'default';
 				e.newGuest = new electron.BrowserWindow(options);
 			}
 		} else {


### PR DESCRIPTION
This should resolve #92. 

Currently, Messenger's calls blocks the window from closing while call is active. I'm not sure if we should override that behavior. Also dark mode doesn't propagate to the call window yet.