### PR TITLE
Reload on system resume to refresh conversations

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "electron-localshortcut": "^1.1.1",
     "electron-log": "^2.0.2",
     "electron-updater": "^1.3.2",
-    "is-reachable": "^2.3.2",
+    "is-online": "^7.0.0",
     "minimist": "^1.2.0",
-    "promise-retry": "^1.1.1"
+    "p-retry": "^1.0.0"
   },
   "devDependencies": {
     "electron": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
     "electron-debug": "^1.0.0",
     "electron-dl": "^1.0.0",
     "electron-is-dev": "^0.1.2",
+    "electron-localshortcut": "^1.1.1",
     "electron-log": "^2.0.2",
     "electron-updater": "^1.3.2",
+    "is-reachable": "^2.3.2",
     "minimist": "^1.2.0",
-    "electron-localshortcut": "^1.1.1"
+    "promise-retry": "^1.1.1"
   },
   "devDependencies": {
     "electron": "1.6.7",


### PR DESCRIPTION
Fixes #103.

We'll try to reload the main window when coming out of suspend, but only when `messenger.com` is reachable in order to prevent blank windows. Caprine will keep retrying until window is able to be refreshed.

This fix relies on `power-monitor` module of electron, which itself has some open issues:
https://github.com/electron/electron/issues/1615
https://github.com/electron/electron/issues/8560
These may prevent this fix from working on some systems.