### PR TITLE
Specify nodejs version to ^6 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "2.3.1",
   "license": "MIT",
   "repository": "sindresorhus/caprine",
+  "engines": {
+    "node": "^6.10.3"
+  },
   "author": {
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",


### PR DESCRIPTION
As the nodejs version defined in .travis.yml, specify the version in package.json