### PR TITLE
Add insert GIF shortcut

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -32,6 +32,10 @@ ipc.on('find', () => {
 	document.querySelector('._58al').focus();
 });
 
+ipc.on('insert-gif', () => {
+	document.querySelector('._yht').click();
+});
+
 ipc.on('next-conversation', nextConversation);
 
 ipc.on('previous-conversation', previousConversation);

--- a/menu.js
+++ b/menu.js
@@ -265,6 +265,13 @@ const macosTpl = [
 				}
 			},
 			{
+				label: 'Insert GIF',
+				accelerator: 'CmdOrCtrl+G',
+				click() {
+					sendAction('insert-gif');
+				}
+			},
+			{
 				type: 'separator'
 			},
 			{
@@ -327,6 +334,13 @@ const otherTpl = [
 				accelerator: 'Ctrl+F',
 				click() {
 					sendAction('find');
+				}
+			},
+			{
+				label: 'Insert GIF',
+				accelerator: 'Ctrl+G',
+				click() {
+					sendAction('insert-gif');
 				}
 			},
 			{

--- a/menu.js
+++ b/menu.js
@@ -266,7 +266,7 @@ const macosTpl = [
 			},
 			{
 				label: 'Insert GIF',
-				accelerator: 'CmdOrCtrl+G',
+				accelerator: 'Cmd+G',
 				click() {
 					sendAction('insert-gif');
 				}

--- a/readme.md
+++ b/readme.md
@@ -106,11 +106,11 @@ Description            | Keys
 -----------------------| -----------------------
 New conversation       | <kbd>Cmd/Ctrl</kbd> <kbd>n</kbd>
 Search conversations   | <kbd>Cmd/Ctrl</kbd> <kbd>f</kbd>
-Insert GIF             | <kbd>Cmd/Ctrl</kbd> <kbd>g</kbd>
 Toggle "Dark mode"     | <kbd>Cmd/Ctrl</kbd> <kbd>d</kbd>
 Next conversation      | <kbd>Cmd/Ctrl</kbd> <kbd>]</kbd> or <kbd>Ctrl</kbd> <kbd>Tab</kbd>
 Previous conversation  | <kbd>Cmd/Ctrl</kbd> <kbd>[</kbd> or <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>Tab</kbd>
 Jump to conversation   | <kbd>Cmd/Ctrl</kbd> <kbd>1</kbd>…<kbd>9</kbd>
+Insert GIF             | <kbd>Cmd/Ctrl</kbd> <kbd>g</kbd>
 Mute conversation      | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>m</kbd>
 Archive conversation   | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>a</kbd>
 Delete conversation    | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>d</kbd>

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ Description            | Keys
 -----------------------| -----------------------
 New conversation       | <kbd>Cmd/Ctrl</kbd> <kbd>n</kbd>
 Search conversations   | <kbd>Cmd/Ctrl</kbd> <kbd>f</kbd>
+Insert GIF             | <kbd>Cmd/Ctrl</kbd> <kbd>g</kbd>
 Toggle "Dark mode"     | <kbd>Cmd/Ctrl</kbd> <kbd>d</kbd>
 Next conversation      | <kbd>Cmd/Ctrl</kbd> <kbd>]</kbd> or <kbd>Ctrl</kbd> <kbd>Tab</kbd>
 Previous conversation  | <kbd>Cmd/Ctrl</kbd> <kbd>[</kbd> or <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>Tab</kbd>


### PR DESCRIPTION
Add a shortcut to launch GIF search <kbd>⌘</kbd><kbd>G</kbd>.

I wanted to additionally add shortcuts to cycle through the gifs but it seems it would require `electron-localshortcut` and might be overly clunky.

_Edit_: actually, I realized <kbd>tab</kbd>  and <kbd>shift</kbd><kbd>tab</kbd> works to cycle through the gifs, so one doesn't have to reach for the mouse after all.

![image](https://cloud.githubusercontent.com/assets/5385846/26729105/a4358eea-47d6-11e7-9925-0411f92fad5e.png)

![image](https://cloud.githubusercontent.com/assets/5385846/26729138/bf6a2112-47d6-11e7-8720-511f5d79565c.png)
