### PR TITLE
Add flashing window on message on Windows

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ module.exports = new Config({
 		},
 		alwaysOnTop: false,
 		bounceDockOnMessage: false,
-		flashWinOnMessage: true,
+		flashWindowOnMessage: true,
 		block: {
 			chatSeen: false,
 			typingIndicator: false

--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ module.exports = new Config({
 		},
 		alwaysOnTop: false,
 		bounceDockOnMessage: false,
+		flashWinOnMessage: true,
 		block: {
 			chatSeen: false,
 			typingIndicator: false

--- a/index.js
+++ b/index.js
@@ -179,7 +179,8 @@ function createMainWindow() {
 
 	win.on('focus', () => {
 		if (config.get('flashWindowOnMessage')) {
-			mainWindow.flashFrame(false);
+			// This is a security in the case where messageCount is not reset by page title update
+			win.flashFrame(false);
 		}
 	});
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function updateBadge(title) {
 			// Delegate drawing of overlay icon to renderer process
 			mainWindow.webContents.send('render-overlay-icon', messageCount);
 		}
-		if (config.get('flashWinOnMessage')) {
+		if (config.get('flashWindowOnMessage')) {
 			mainWindow.flashFrame(messageCount !== 0);
 		}
 	}
@@ -175,6 +175,12 @@ function createMainWindow() {
 	win.on('page-title-updated', (e, title) => {
 		e.preventDefault();
 		updateBadge(title);
+	});
+
+	win.on('focus', () => {
+		if (config.get('flashWindowOnMessage')) {
+			mainWindow.flashFrame(false);
+		}
 	});
 
 	return win;

--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ function updateBadge(title) {
 			// Delegate drawing of overlay icon to renderer process
 			mainWindow.webContents.send('render-overlay-icon', messageCount);
 		}
+		if (config.get('flashWinOnMessage')) {
+			mainWindow.flashFrame(messageCount !== 0);
+		}
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function updateBadge(title) {
 			// Delegate drawing of overlay icon to renderer process
 			mainWindow.webContents.send('render-overlay-icon', messageCount);
 		}
+
 		if (config.get('flashWindowOnMessage')) {
 			mainWindow.flashFrame(messageCount !== 0);
 		}

--- a/menu.js
+++ b/menu.js
@@ -372,6 +372,14 @@ const otherTpl = [
 			},
 			{
 				type: 'checkbox',
+				label: 'Flash Window on Message',
+				checked: config.get('flashWinOnMessage'),
+				click(item) {
+					config.set('flashWinOnMessage', item.checked);
+				}
+			},
+			{
+				type: 'checkbox',
 				label: 'Block Seen Indicator',
 				checked: config.get('block.chatSeen'),
 				click(item) {

--- a/menu.js
+++ b/menu.js
@@ -373,9 +373,10 @@ const otherTpl = [
 			{
 				type: 'checkbox',
 				label: 'Flash Window on Message',
-				checked: config.get('flashWinOnMessage'),
+				visible: process.platform === 'win32',
+				checked: config.get('flashWindowOnMessage'),
 				click(item) {
-					config.set('flashWinOnMessage', item.checked);
+					config.set('flashWindowOnMessage', item.checked);
 				}
 			},
 			{


### PR DESCRIPTION
Like bouncing dock icon on MacOs, it is a common feature on Windows to make window (and app icon in task bar) flashing.
This PR implements flashing when a new message is received and adds an option to disable it.
Default is true because it is default behaviour of all chat apps on Windows.