### PR TITLE
Bump electron-localshortcut version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "electron-debug": "^1.0.0",
     "electron-dl": "^1.0.0",
     "electron-is-dev": "^0.1.2",
-    "electron-localshortcut": "^1.1.1",
+    "electron-localshortcut": "^2.0.0",
     "electron-log": "^2.0.2",
     "electron-store": "^1.1.0",
     "electron-updater": "^1.3.2",


### PR DESCRIPTION
Should solve https://github.com/sindresorhus/caprine/issues/202.
I published a twin [PR on electron-debug](https://github.com/sindresorhus/electron-debug/pull/50) that upgrade `electron-localshortcut` there too.

If you want, when you'll publish a new version of `electron-debug`, I'll do another PR here to bump `electron-debug` version too.
This way, we'll avoid `Caprine` dependencies on two different version of `electron-localshortcut`
