### PR TITLE
Add Electron Spellchecker Support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -8,6 +8,13 @@ const listSelector = 'div[role="navigation"] > div > ul';
 const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 
+const { webFrame } = require('electron');
+webFrame.setSpellCheckProvider('en-US', true, {
+	spellCheck (text) {
+		return !(require('spellchecker').isMisspelled(text))
+	}
+});
+
 ipc.on('show-preferences', () => {
 	// Create the menu for the below
 	document.querySelector('._30yy._2fug._p').click();

--- a/browser.js
+++ b/browser.js
@@ -9,7 +9,7 @@ const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 
 const { webFrame } = require('electron');
-webFrame.setSpellCheckProvider('en-US', true, {
+webFrame.setSpellCheckProvider(navigator.language, true, {
 	spellCheck (text) {
 		return !(require('spellchecker').isMisspelled(text))
 	}

--- a/browser.js
+++ b/browser.js
@@ -4,16 +4,19 @@ const config = require('./config');
 
 const {ipcRenderer: ipc} = electron;
 
+// Spellchecking for user input
+const { SpellCheckHandler, ContextMenuListener, ContextMenuBuilder } = require('electron-spellchecker');
+window.spellCheckHandler = new SpellCheckHandler();
+window.spellCheckHandler.attachToInput();
+window.spellCheckHandler.switchLanguage(navigator.language);
+let contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler);
+let contextMenuListener = new ContextMenuListener((info) => {
+  contextMenuBuilder.showPopupMenu(info);
+});
+
 const listSelector = 'div[role="navigation"] > div > ul';
 const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
-
-const { webFrame } = require('electron');
-webFrame.setSpellCheckProvider(navigator.language, true, {
-	spellCheck (text) {
-		return !(require('spellchecker').isMisspelled(text))
-	}
-});
 
 ipc.on('show-preferences', () => {
 	// Create the menu for the below

--- a/browser.js
+++ b/browser.js
@@ -1,17 +1,18 @@
 'use strict';
 const electron = require('electron');
+const {SpellCheckHandler, ContextMenuListener, ContextMenuBuilder} = require('electron-spellchecker');
 const config = require('./config');
 
 const {ipcRenderer: ipc} = electron;
 
 // Spellchecking for user input
-const { SpellCheckHandler, ContextMenuListener, ContextMenuBuilder } = require('electron-spellchecker');
 window.spellCheckHandler = new SpellCheckHandler();
 window.spellCheckHandler.attachToInput();
 window.spellCheckHandler.switchLanguage(navigator.language);
-let contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler);
-let contextMenuListener = new ContextMenuListener((info) => {
-  contextMenuBuilder.showPopupMenu(info);
+const contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler);
+// eslint-disable-next-line no-unused-vars
+const contextMenuListener = new ContextMenuListener(info => {
+	contextMenuBuilder.showPopupMenu(info);
 });
 
 const listSelector = 'div[role="navigation"] > div > ul';

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const {app, ipcMain} = electron;
 app.setAppUserModelId('com.sindresorhus.caprine');
 app.disableHardwareAcceleration();
 
-require('electron-debug')({ enabled: true });
+require('electron-debug')({enabled: true});
 require('electron-dl')();
 require('electron-context-menu')();
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const {app, ipcMain} = electron;
 app.setAppUserModelId('com.sindresorhus.caprine');
 app.disableHardwareAcceleration();
 
-require('electron-debug')({enabled: true});
+require('electron-debug')({ enabled: true });
 require('electron-dl')();
 require('electron-context-menu')();
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ app.disableHardwareAcceleration();
 
 require('electron-debug')({enabled: true});
 require('electron-dl')();
-require('electron-context-menu')();
 
 let mainWindow;
 let isQuitting = false;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"electron-is-dev": "^0.1.2",
 		"electron-localshortcut": "^2.0.0",
 		"electron-log": "^2.0.2",
+		"electron-spellchecker": "^1.1.0",
 		"electron-store": "^1.1.0",
 		"electron-updater": "^1.3.2",
 		"facebook-locales": "^1.0.464",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"dist": "build"
 	},
 	"dependencies": {
-		"electron-context-menu": "^0.8.0",
 		"electron-debug": "^1.0.0",
 		"electron-dl": "^1.0.0",
 		"electron-is-dev": "^0.1.2",


### PR DESCRIPTION
- Detects the user's language and uses the correct dictionary
- Removes `electron-context-menu` as it is not needed.

Closes https://github.com/sindresorhus/caprine/issues/14