### PR TITLE
Fix issue with paste confirmation when AlwaysOnTop is activated

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ app.on('ready', () => {
 		const clipboardHasImage = electron.clipboard.availableFormats().some(type => type.includes('image'));
 
 		if (clipboardHasImage && config.get('confirmImagePaste')) {
-			electron.dialog.showMessageBox({
+			electron.dialog.showMessageBox(mainWindow, {
 				type: 'info',
 				buttons: ['Send', 'Cancel'],
 				message: 'Are you sure you want to send the image in the clipboard?',


### PR DESCRIPTION
On Windows, if user has activated AlwaysOnTop option, when pasting an image: confirmation popup  appears behind (and maybe not visible).
Changing this popup as a main window modal fixes this issue.