### PR TITLE
Add Preferences keyboard shortcut to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ Delete conversation    | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>d</kbd>
 Toggle "Always on Top" | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>t</kbd>
 Toggle window menu     | <kbd>Alt</kbd> *(Windows only)*
 Toggle sidebar         | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>s</kbd>
+Preferences            | <kbd>Cmd/Ctrl</kbd> <kbd>,</kbd>
 
 
 ---


### PR DESCRIPTION
Simply add information about the Preferences menu to the readme. I use a minimal window manager on Linux, so I have no menu bar, and therefore had to browse the source code to find the Preferences keyboard shortcut :)