### PR TITLE
Add mute notification option

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -76,13 +76,11 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 		openPreferences();
 	}
 
-	const notificationCheckbox =
-		document.querySelector('._374b:nth-of-type(3) ._55sg._4ng2._kv1 input');
+	const notificationCheckbox = document.querySelector('._374b:nth-of-type(3) ._55sg._4ng2._kv1 input');
 
 	if (defaultStatus === undefined) {
 		notificationCheckbox.click();
-	} else if ((defaultStatus && !notificationCheckbox.checked) ||
-						(!defaultStatus && notificationCheckbox.checked)) {
+	} else if ((defaultStatus && !notificationCheckbox.checked) || (!defaultStatus && notificationCheckbox.checked)) {
 		notificationCheckbox.click();
 	}
 

--- a/browser.js
+++ b/browser.js
@@ -9,7 +9,9 @@ const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 
 ipc.on('show-preferences', () => {
-	if (isPreferencesOpen()) return;
+	if (isPreferencesOpen()) {
+		return;
+	}
 
 	openPreferences();
 });
@@ -67,16 +69,28 @@ function setSidebarVisibility() {
 	ipc.send('set-sidebar-visibility');
 }
 
-ipc.on('toggle-mute-notifications', () => {
+ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 	const wasPreferencesOpen = isPreferencesOpen();
 
-	if (!wasPreferencesOpen) openPreferences();
+	if (!wasPreferencesOpen) {
+		openPreferences();
+	}
 
 	const notificationCheckbox =
 		document.querySelector('._374b:nth-of-type(3) ._55sg._4ng2._kv1 input');
-	notificationCheckbox.click();
 
-	if (!wasPreferencesOpen) closePreferences();
+	if (defaultStatus === undefined) {
+		notificationCheckbox.click();
+	} else if ((defaultStatus && !notificationCheckbox.checked) ||
+						(!defaultStatus && notificationCheckbox.checked)) {
+		notificationCheckbox.click();
+	}
+
+	ipc.send('mute-notifications-toggled', !notificationCheckbox.checked);
+
+	if (!wasPreferencesOpen) {
+		closePreferences();
+	}
 });
 
 function setDarkMode() {
@@ -240,7 +254,7 @@ function openDeleteModal() {
 	document.querySelector(selector).click();
 }
 
-function openPreferences () {
+function openPreferences() {
 	// Create the menu for the below
 	document.querySelector('._30yy._2fug._p').click();
 
@@ -248,11 +262,11 @@ function openPreferences () {
 	nodes[nodes.length - 1].click();
 }
 
-function isPreferencesOpen () {
+function isPreferencesOpen() {
 	return document.querySelector('._3quh._30yy._2t_._5ixy');
 }
 
-function closePreferences () {
+function closePreferences() {
 	const doneButton = document.querySelector('._3quh._30yy._2t_._5ixy');
 	doneButton.click();
 }

--- a/browser.js
+++ b/browser.js
@@ -9,11 +9,9 @@ const conversationSelector = '._4u-c._1wfr > ._5f0v.uiScrollableArea';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 
 ipc.on('show-preferences', () => {
-	// Create the menu for the below
-	document.querySelector('._30yy._2fug._p').click();
+	if (isPreferencesOpen()) return;
 
-	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:first-child a');
-	nodes[nodes.length - 1].click();
+	openPreferences();
 });
 
 ipc.on('new-conversation', () => {
@@ -68,6 +66,18 @@ function setSidebarVisibility() {
 	document.documentElement.classList.toggle('sidebar-hidden', config.get('sidebarHidden'));
 	ipc.send('set-sidebar-visibility');
 }
+
+ipc.on('toggle-mute-notifications', () => {
+	const wasPreferencesOpen = isPreferencesOpen();
+
+	if (!wasPreferencesOpen) openPreferences();
+
+	const notificationCheckbox =
+		document.querySelector('._374b:nth-of-type(3) ._55sg._4ng2._kv1 input');
+	notificationCheckbox.click();
+
+	if (!wasPreferencesOpen) closePreferences();
+});
 
 function setDarkMode() {
 	document.documentElement.classList.toggle('dark-mode', config.get('darkMode'));
@@ -228,6 +238,23 @@ function openDeleteModal() {
 
 	const selector = '._54nq._2i-c._558b._2n_z li:nth-child(4) a';
 	document.querySelector(selector).click();
+}
+
+function openPreferences () {
+	// Create the menu for the below
+	document.querySelector('._30yy._2fug._p').click();
+
+	const nodes = document.querySelectorAll('._54nq._2i-c._558b._2n_z li:first-child a');
+	nodes[nodes.length - 1].click();
+}
+
+function isPreferencesOpen () {
+	return document.querySelector('._3quh._30yy._2t_._5ixy');
+}
+
+function closePreferences () {
+	const doneButton = document.querySelector('._3quh._30yy._2t_._5ixy');
+	doneButton.click();
 }
 
 // Inject a global style node to maintain custom appearance after conversation change or startup

--- a/config.js
+++ b/config.js
@@ -22,6 +22,7 @@ module.exports = new Store({
 		confirmImagePaste: true,
 		useWorkChat: false,
 		sidebarHidden: false,
-		autoHideMenuBar: false
+		autoHideMenuBar: false,
+		notificationsMuted: false
 	}
 });

--- a/index.js
+++ b/index.js
@@ -138,10 +138,9 @@ function setUserLocale() {
 }
 
 function setNotificationsMute(status) {
-	const mainMenuItemIndex = process.platform === 'darwin' ? 3 : 14;
-	const muteMenuItem = Menu.getApplicationMenu().items[0].submenu.items[mainMenuItemIndex];
+	const muteMenuItem = Menu.getApplicationMenu().items[0].submenu.items
+		.find(item => (item.label === 'Mute Notifications'));
 
-	console.log(status);
 	config.set('notificationsMuted', status);
 	muteMenuItem.checked = status;
 

--- a/index.js
+++ b/index.js
@@ -215,6 +215,17 @@ app.on('ready', () => {
 	mainWindow = createMainWindow();
 	tray.create(mainWindow);
 
+	const dockMenu = electron.Menu.buildFromTemplate([
+		{
+			label: 'Mute Notifications',
+			type: 'checkbox',
+			click(event) {
+				mainWindow.webContents.send('toggle-mute-notifications');
+			}
+		}
+	])
+	app.dock.setMenu(dockMenu)
+
 	enableHiresResources();
 
 	const {webContents} = mainWindow;

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ function setUserLocale() {
 
 function setNotificationsMute(status) {
 	const muteMenuItem = Menu.getApplicationMenu().items[0].submenu.items
-		.find(item => (item.label === 'Mute Notifications'));
+		.find(item => item.label === 'Mute Notifications');
 
 	config.set('notificationsMuted', status);
 	muteMenuItem.checked = status;

--- a/menu.js
+++ b/menu.js
@@ -138,6 +138,14 @@ const macosTpl = [
 				}
 			},
 			{
+				label: 'Mute Notifications',
+				type: 'checkbox',
+				checked: config.get('notificationsMuted'),
+				click() {
+					sendAction('toggle-mute-notifications');
+				}
+			},
+			{
 				label: 'Show Unread Badge',
 				type: 'checkbox',
 				checked: config.get('showUnreadBadge'),
@@ -441,6 +449,14 @@ const otherTpl = [
 				checked: config.get('launchMinimized'),
 				click() {
 					config.set('launchMinimized', !config.get('launchMinimized'));
+				}
+			},
+			{
+				label: 'Mute Notifications',
+				type: 'checkbox',
+				checked: config.get('notificationsMuted'),
+				click() {
+					sendAction('toggle-mute-notifications');
 				}
 			},
 			{

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,10 @@ On *macOS*, you can toggle the window vibrancy effect in the `View` menu.
 
 You can choose to prevent people from knowing when you've seen a message or are currently typing. Both options are available under the `Caprine`/`File` menu.
 
+### Mute desktop notifications
+
+You can easily disable receiving notifications from the main menu, or on _macOS_, from the Dock.
+
 ### Prevents link tracking
 
 Links that you click on will not be tracked by Facebook.

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ You can choose to prevent people from knowing when you've seen a message or are 
 
 ### Mute desktop notifications
 
-You can easily disable receiving notifications from the main menu, or on _macOS_, from the Dock.
+You can quickly disable receiving notifications from the `Caprine`/`File` menu or the Dock on macOS.
 
 ### Prevents link tracking
 


### PR DESCRIPTION
This PR adds a checkable dock option with what the user can mute or unmute the app's notifications, so they don't appear, kind of like with the do not disturb mode on macOS.

Also refactors and fixes the show preferences mechanism, because if the preferences was open and the user opened it again, it stacked.