### PR TITLE
Add sender color style to group chat

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -106,6 +106,11 @@ html.dark-mode ._14-7 ._58ah ._58al {
 	color: var(--base-seventy);
 }
 
+/* Message list: sender (group chat) */
+html.dark-mode ._ih3 {
+	color: var(--base-fourty);
+}
+
 /* Messages list: user info (is in contacts) */
 html.dark-mode ._36zg-e {
 	color: var(--base-seventy) !important;

--- a/workchat.css
+++ b/workchat.css
@@ -85,8 +85,3 @@ html.dark-mode ._aou {
 html.dark-mode ._4kf5 {
 	background: var(--base) !important;
 }
-
-/* Message list: sender (group chat) */
-html.dark-mode ._ih3 {
-	color: var(--base-fourty);
-}


### PR DESCRIPTION
This style isn't specific to workchat, instead it can be applied to darkmode.

Fixes #273