### PR TITLE
Center names in titlebar

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -72,6 +72,11 @@ body {
 	display: none;
 }
 
+/* Center names in titlebar */
+._5742 {
+	text-align: center !important;
+}
+
 /* Narrower titlebar */
 ._36ic,
 ._5742 {


### PR DESCRIPTION
Overrides `text-align: left` that are applied when multiple names appear.
Fixes #291 