### PR TITLE
Don't use mainWindow.minimize() to run Caprine without startup window

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,9 @@ app.on('ready', () => {
 			webContents.insertCSS(fs.readFileSync(path.join(__dirname, 'workchat.css'), 'utf8'));
 		}
 
-		if (argv.minimize) {
+		if (argv['startup-window'] === false) {
+			mainWindow.hide();
+		} else if (argv.minimize) {
 			mainWindow.minimize();
 		} else {
 			mainWindow.show();

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ You can send code blocks by using [Markdown syntax](https://github.com/adam-p/ma
 
 When closing the window, the app will continue running in the background, in the dock on macOS and the tray on Linux/Windows. Right-click the dock/tray icon and choose `Quit` to completely quit the app. On macOS, click the dock icon to show the window. On Linux, right-click the tray icon and choose `Toggle` to toggle the window. On Windows, click the tray icon to toggle the window.
 
-If you like to have Caprine minimized on startup, open it from the command-line with the `--minimize` flag.
+If you like to have Caprine hidden or minimized on startup, open it from the command-line with `--no-startup-window` flag or `--minimize` flag respectively.
 
 ### Keyboard shortcuts
 


### PR DESCRIPTION
There's `--minimize` flag which should stop startup window from appearing but
it uses `mainWindow.minimize()` which causes [undesired effect](https://goo.gl/629GdB) in Linux

On the other hand, `--no-startup-window` stop startup window from appearing by
using `mainWindow.hide()` which doesn't produce any side-effect

[Demo video](https://goo.gl/629GdB)

Fixes #318 

### Alternate solution

Instead of adding `--no-startup-window`, just edit [this line](https://github.com/KSXGitHub/caprine/blob/flag-minimize/index.js#L257)

[Branch](https://github.com/KSXGitHub/caprine/tree/flag-minimize)