### PR TITLE
Update electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"minimist": "^1.2.0"
 	},
 	"devDependencies": {
-		"electron": "1.6.11",
+		"electron": "1.8.1",
 		"electron-builder": "19.42.2",
 		"xo": "*"
 	},


### PR DESCRIPTION
I'm suggesting to update electron version since it has fixes in chromium
(version 60/61) for tray icon. With electron version 1.8.1 tray icons is
displayed in Ubutnu 17.10 (Gnome).