### PR TITLE
Call immediately when starting a audio/video call

### DIFF
--- a/browser-call.js
+++ b/browser-call.js
@@ -1,3 +1,6 @@
+'use strict';
+const elementReady = require('element-ready');
+
 (async () => {
 	const startCallButton = await elementReady('._3quh._30yy._2t_');
 	startCallButton.click();

--- a/browser-call.js
+++ b/browser-call.js
@@ -1,23 +1,4 @@
-'use strict';
-const electron = require('electron');
-
-const {ipcRenderer: ipc} = electron;
-
-const onReady = fn => {
-	window.addEventListener('load', () => {
-		const check = () => {
-			if (document.querySelector('._3quh._30yy._2t_')) {
-				fn();
-			} else {
-				setTimeout(check, 100);
-			}
-		};
-
-		check();
-	});
-}
-
-onReady(() => {
-	// Start call
-	document.querySelector('._3quh._30yy._2t_').click();
+(async () => {
+	const startCallButton = await elementReady('._3quh._30yy._2t_');
+	startCallButton.click();
 });

--- a/browser-call.js
+++ b/browser-call.js
@@ -1,4 +1,4 @@
 (async () => {
 	const startCallButton = await elementReady('._3quh._30yy._2t_');
 	startCallButton.click();
-});
+})();

--- a/browser-call.js
+++ b/browser-call.js
@@ -1,0 +1,23 @@
+'use strict';
+const electron = require('electron');
+
+const {ipcRenderer: ipc} = electron;
+
+const onReady = fn => {
+	window.addEventListener('load', () => {
+		const check = () => {
+			if (document.querySelector('._3quh._30yy._2t_')) {
+				fn();
+			} else {
+				setTimeout(check, 100);
+			}
+		};
+
+		check();
+	});
+}
+
+onReady(() => {
+	// Start call
+	document.querySelector('._3quh._30yy._2t_').click();
+});

--- a/index.js
+++ b/index.js
@@ -258,15 +258,16 @@ app.on('ready', () => {
 		}
 	});
 
-	webContents.on('new-window', (e, url, frameName, disposition, options) => {
-		e.preventDefault();
+	webContents.on('new-window', (event, url, frameName, disposition, options) => {
+		event.preventDefault();
+
 		if (url === 'about:blank') {
-			if (frameName !== 'about:blank') {  // Voice/video call popup
+			if (frameName !== 'about:blank') { // Voice/video call popup
 				options.show = true;
 				options.titleBarStyle = 'default';
-				options.webPreferences.sandbox = true;
+				options.webPreferences.nodeIntegration = false;
 				options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
-				e.newGuest = new electron.BrowserWindow(options);
+				event.newGuest = new electron.BrowserWindow(options);
 			}
 		} else {
 			if (url.startsWith(trackingUrlPrefix)) {

--- a/index.js
+++ b/index.js
@@ -265,6 +265,7 @@ app.on('ready', () => {
 				options.show = true;
 				options.titleBarStyle = 'default';
 				options.webPreferences.sandbox = true;
+				options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
 				e.newGuest = new electron.BrowserWindow(options);
 			}
 		} else {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "electron-log": "^2.0.2",
     "electron-store": "^1.1.0",
     "electron-updater": "^2.16.1",
+    "element-ready": "^2.2.0",
     "facebook-locales": "^1.0.464"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes this pointless step and calls the person right away:

<img width="1392" alt="screen shot 2017-12-02 at 7 12 56 pm" src="https://user-images.githubusercontent.com/697676/33517915-13c6ae62-d795-11e7-88b8-bfa31f04464e.png">

I think this step isn't needed, because I already expressed my intent to call that person by clicking on the button.

This PR is extracted from the Touch Bar work.