### PR TITLE
Fix photo info color in dark mode

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -316,6 +316,15 @@ html.dark-mode ._4rph ._4rpj {
 	color: var(--base-seventy);
 }
 
+/* Photos info color */
+html.dark-mode ._2zn2 {
+	color: var(--base-seventy);
+}
+
+html.dark-mode ._2zn6 {
+	color: var(--base-fourty);
+}
+
 /* New conversation contact list: popup */
 html.dark-mode ._2y8_ {
 	background: transparent;


### PR DESCRIPTION
In dark mode, some of photo info text is in dark color. This commit
fixes that.