### PR TITLE
Fix opened right sidebar in compact mode

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -126,6 +126,10 @@ html.sidebar-hidden ._1enh {
 	._30yy[href='/new'] {
 		display: none !important;
 	}
+
+	._4_j5 {
+		display: none !important;
+	}
 }
 
 /* Don't show outline on clickable elements except in the delete/mute modal so that we know what we are selecting */

--- a/browser.css
+++ b/browser.css
@@ -127,6 +127,7 @@ html.sidebar-hidden ._1enh {
 		display: none !important;
 	}
 
+	/* Hide right sidebar in compact mode */
 	._4_j5 {
 		display: none !important;
 	}


### PR DESCRIPTION
The right-sidebar was kept opened in compact mode and it was difficult
to read messages. This fixes it and hides right-sidebar in compact mode.

Closes: https://github.com/sindresorhus/caprine/issues/350