### PR TITLE
WIP: Add upload shortcut

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -48,6 +48,10 @@ ipc.on('insert-emoji', () => {
 	document.querySelector('._5s2p').click();
 });
 
+ipc.on('insert-files', () => {
+	document.querySelector('._260t').click();
+});
+
 ipc.on('next-conversation', nextConversation);
 
 ipc.on('previous-conversation', previousConversation);

--- a/menu.js
+++ b/menu.js
@@ -327,6 +327,13 @@ const macosTpl = [
 				}
 			},
 			{
+				label: 'Insert Files',
+				accelerator: 'Cmd+U',
+				click() {
+					sendAction('insert-files');
+				}
+			},
+			{
 				type: 'separator'
 			},
 			{
@@ -403,6 +410,13 @@ const otherTpl = [
 				accelerator: 'Ctrl+E',
 				click() {
 					sendAction('insert-emoji');
+				}
+			},
+			{
+				label: 'Insert Files',
+				accelerator: 'Ctrl+U',
+				click() {
+					sendAction('insert-files');
 				}
 			},
 			{


### PR DESCRIPTION
**This does not work now.**

Focusing a `<input type="file">` via JavaScript seems to not work.
I think it does not work because of browser policy. https://stackoverflow.com/q/210643

Do you know anything that can be done to make it work? Maybe allow it somehow?