### PR TITLE
Fixed event box colors in dark mode

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -108,7 +108,8 @@ html.dark-mode ._5742 {
 
 /* Message list: header above (event) */
 html.dark-mode ._3nta {
-	border-bottom: 1px solid rgba(25, 38, 51, 0.8);
+	background: var(--container-color) !important;
+	border-bottom: 1px solid var(--base-five);
 }
 
 /* Message list: header above (event) */
@@ -146,6 +147,27 @@ html.dark-mode ._36zg-e {
 /* Messages list: user info */
 html.dark-mode ._1n-e {
 	color: var(--base-fourty);
+}
+
+/* Messages list: event box (event name) */
+html.dark-mode ._618l {
+	color: var(--base-seventy);
+}
+
+/* Messages list: event box (event icon) */
+html.dark-mode ._618m {
+	width: 28px;
+}
+
+/* Messages list: event box (event description) */
+html.dark-mode ._618n {
+	color: var(--base-thiry);
+}
+
+/* Messages list: event box (line) */
+html.dark-mode ._618k div hr {
+	background: var(--container-color) !important;
+	border-top: 1px solid var(--base-five);
 }
 
 /* Messages list: text header above the messages */


### PR DESCRIPTION
Fixed the small event box bottom line color in the top of messages list
and the large event box in the messages list. Also made a workaround for
event icons that are eaten up by event title (set a fixed width).