### PR TITLE
Add `Show Message Buttons` option

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -133,16 +133,6 @@ html.sidebar-hidden ._1enh {
 	}
 }
 
-/* Aditional icons message box: hide */
-._39bj {
-	display: none !important;
-}
-
-._4rv4:hover>._39bj {
-	display: flex !important;
-}
-
-
 /* Don't show outline on clickable elements except in the delete/mute modal so that we know what we are selecting */
 a,
 *[role='button'] {

--- a/browser.css
+++ b/browser.css
@@ -133,6 +133,16 @@ html.sidebar-hidden ._1enh {
 	}
 }
 
+/* Aditional icons message box: hide */
+._39bj {
+	display: none !important;
+}
+
+._4rv4:hover>._39bj {
+	display: flex !important;
+}
+
+
 /* Don't show outline on clickable elements except in the delete/mute modal so that we know what we are selecting */
 a,
 *[role='button'] {

--- a/browser.js
+++ b/browser.js
@@ -92,12 +92,9 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 	}
 });
 
-ipc.on('toggle-message-buttons', () => {
-	elementReady('._39bj').then(messageButtons => {
-		messageButtons.style.display = config.get('showMessageButtons') ? 'flex' : 'none';
-	}).catch(err => {
-		console.error(err);
-	});
+ipc.on('toggle-message-buttons', async () => {
+	const messageButtons = await elementReady('._39bj');
+	messageButtons.style.display = config.get('showMessageButtons') ? 'flex' : 'none';
 });
 
 function setDarkMode() {

--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,6 @@
 'use strict';
 const electron = require('electron');
+const elementReady = require('element-ready');
 const config = require('./config');
 
 const {ipcRenderer: ipc} = electron;
@@ -92,8 +93,11 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 });
 
 ipc.on('toggle-message-buttons', () => {
-	const messageButtons = document.querySelector('._39bj');
-	messageButtons.style.display = config.get('showMessageButtons') ? 'flex' : 'none';
+	elementReady('._39bj').then(messageButtons => {
+		messageButtons.style.display = config.get('showMessageButtons') ? 'flex' : 'none';
+	}).catch(err => {
+		console.error(err);
+	});
 });
 
 function setDarkMode() {

--- a/browser.js
+++ b/browser.js
@@ -91,6 +91,22 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 	}
 });
 
+ipc.on('toggle-message-buttons', () => {
+	const messageButtons = document.querySelector('._39bj');
+
+	let messageButtonsStatus = window.getComputedStyle(messageButtons, null).getPropertyValue('display');
+
+	if (config.get('showMessageButtons')) {
+		messageButtons.style.display = 'flex';
+	} else {
+		messageButtons.style.display = 'none';
+	}
+
+	messageButtonsStatus = window.getComputedStyle(messageButtons, null).getPropertyValue('display');
+
+	ipc.send('message-buttons-toggled', messageButtonsStatus === 'flex');
+});
+
 function setDarkMode() {
 	document.documentElement.classList.toggle('dark-mode', config.get('darkMode'));
 	ipc.send('set-vibrancy');

--- a/browser.js
+++ b/browser.js
@@ -94,17 +94,7 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 ipc.on('toggle-message-buttons', () => {
 	const messageButtons = document.querySelector('._39bj');
 
-	let messageButtonsStatus = window.getComputedStyle(messageButtons, null).getPropertyValue('display');
-
-	if (config.get('showMessageButtons')) {
-		messageButtons.style.display = 'flex';
-	} else {
-		messageButtons.style.display = 'none';
-	}
-
-	messageButtonsStatus = window.getComputedStyle(messageButtons, null).getPropertyValue('display');
-
-	ipc.send('message-buttons-toggled', messageButtonsStatus === 'flex');
+	messageButtons.style.display = (config.get('showMessageButtons') ? 'flex' : 'none');
 });
 
 function setDarkMode() {

--- a/browser.js
+++ b/browser.js
@@ -93,8 +93,7 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 
 ipc.on('toggle-message-buttons', () => {
 	const messageButtons = document.querySelector('._39bj');
-
-	messageButtons.style.display = (config.get('showMessageButtons') ? 'flex' : 'none');
+	messageButtons.style.display = config.get('showMessageButtons') ? 'flex' : 'none';
 });
 
 function setDarkMode() {

--- a/config.js
+++ b/config.js
@@ -13,6 +13,7 @@ module.exports = new Store({
 		alwaysOnTop: false,
 		bounceDockOnMessage: false,
 		showUnreadBadge: true,
+		showMessageButtons: true,
 		launchMinimized: false,
 		flashWindowOnMessage: true,
 		block: {

--- a/index.js
+++ b/index.js
@@ -285,7 +285,11 @@ app.on('ready', () => {
 			mainWindow.show();
 		}
 
-		mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
+		// Workaround for setting config after startup
+		setTimeout(() => {
+			mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
+			mainWindow.webContents.send('toggle-message-buttons', config.get('showMessageButtons'));
+		}, 1000);
 	});
 
 	webContents.on('new-window', (event, url, frameName, disposition, options) => {

--- a/index.js
+++ b/index.js
@@ -156,6 +156,20 @@ function setNotificationsMute(status) {
 	}
 }
 
+function setMessageButtonsVisible(status) {
+	const label = 'Show Message Buttons';
+	const buttonsVisibleMenuItem = Menu.getApplicationMenu().items[0].submenu.items
+		.find(x => x.label === label);
+
+	config.set('showMessageButtons', status);
+	buttonsVisibleMenuItem.checked = status;
+
+	if (process.platform === 'darwin') {
+		const item = dockMenu.items.find(x => x.label === label);
+		item.checked = status;
+	}
+}
+
 function createMainWindow() {
 	const lastWindowState = config.get('lastWindowState');
 	const isDarkMode = config.get('darkMode');
@@ -319,6 +333,10 @@ ipcMain.on('set-vibrancy', () => {
 
 ipcMain.on('mute-notifications-toggled', (event, status) => {
 	setNotificationsMute(status);
+});
+
+ipcMain.on('message-buttons-toggled', (event, status) => {
+	setMessageButtonsVisible(status);
 });
 
 app.on('activate', () => {

--- a/index.js
+++ b/index.js
@@ -238,6 +238,15 @@ app.on('ready', () => {
 				click() {
 					mainWindow.webContents.send('toggle-mute-notifications');
 				}
+			},
+			{
+				label: 'Show Message Buttons',
+				type: 'checkbox',
+				checked: config.get('showMessageButtons'),
+				click() {
+					config.set('showMessageButtons', !config.get('showMessageButtons'));
+					mainWindow.webContents.send('toggle-message-buttons');
+				}
 			}
 		]);
 		app.dock.setMenu(dockMenu);

--- a/index.js
+++ b/index.js
@@ -238,15 +238,6 @@ app.on('ready', () => {
 				click() {
 					mainWindow.webContents.send('toggle-mute-notifications');
 				}
-			},
-			{
-				label: 'Show Message Buttons',
-				type: 'checkbox',
-				checked: config.get('showMessageButtons'),
-				click() {
-					config.set('showMessageButtons', !config.get('showMessageButtons'));
-					mainWindow.webContents.send('toggle-message-buttons');
-				}
 			}
 		]);
 		app.dock.setMenu(dockMenu);
@@ -328,17 +319,6 @@ ipcMain.on('set-vibrancy', () => {
 
 ipcMain.on('mute-notifications-toggled', (event, status) => {
 	setNotificationsMute(status);
-});
-
-ipcMain.on('message-buttons-toggled', (event, status) => {
-	const label = 'Show Message Buttons';
-
-	config.set('showMessageButtons', status);
-
-	if (process.platform === 'darwin') {
-		const item = dockMenu.items.find(x => x.label === label);
-		item.checked = status;
-	}
 });
 
 app.on('activate', () => {

--- a/index.js
+++ b/index.js
@@ -285,11 +285,8 @@ app.on('ready', () => {
 			mainWindow.show();
 		}
 
-		// Workaround for setting config after startup
-		setTimeout(() => {
-			mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
-			mainWindow.webContents.send('toggle-message-buttons', config.get('showMessageButtons'));
-		}, 1000);
+		mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
+		mainWindow.webContents.send('toggle-message-buttons', config.get('showMessageButtons'));
 	});
 
 	webContents.on('new-window', (event, url, frameName, disposition, options) => {

--- a/index.js
+++ b/index.js
@@ -158,11 +158,8 @@ function setNotificationsMute(status) {
 
 function setMessageButtonsVisible(status) {
 	const label = 'Show Message Buttons';
-	const buttonsVisibleMenuItem = Menu.getApplicationMenu().items[0].submenu.items
-		.find(x => x.label === label);
 
 	config.set('showMessageButtons', status);
-	buttonsVisibleMenuItem.checked = status;
 
 	if (process.platform === 'darwin') {
 		const item = dockMenu.items.find(x => x.label === label);

--- a/index.js
+++ b/index.js
@@ -156,17 +156,6 @@ function setNotificationsMute(status) {
 	}
 }
 
-function setMessageButtonsVisible(status) {
-	const label = 'Show Message Buttons';
-
-	config.set('showMessageButtons', status);
-
-	if (process.platform === 'darwin') {
-		const item = dockMenu.items.find(x => x.label === label);
-		item.checked = status;
-	}
-}
-
 function createMainWindow() {
 	const lastWindowState = config.get('lastWindowState');
 	const isDarkMode = config.get('darkMode');
@@ -333,7 +322,14 @@ ipcMain.on('mute-notifications-toggled', (event, status) => {
 });
 
 ipcMain.on('message-buttons-toggled', (event, status) => {
-	setMessageButtonsVisible(status);
+	const label = 'Show Message Buttons';
+
+	config.set('showMessageButtons', status);
+
+	if (process.platform === 'darwin') {
+		const item = dockMenu.items.find(x => x.label === label);
+		item.checked = status;
+	}
 });
 
 app.on('activate', () => {

--- a/menu.js
+++ b/menu.js
@@ -55,6 +55,15 @@ const viewSubmenu = [
 		click() {
 			sendAction('toggle-dark-mode');
 		}
+	},
+	{
+		label: 'Show Message Buttons',
+		type: 'checkbox',
+		checked: config.get('showMessageButtons'),
+		click() {
+			config.set('showMessageButtons', !config.get('showMessageButtons'));
+			sendAction('toggle-message-buttons');
+		}
 	}
 ];
 

--- a/menu.js
+++ b/menu.js
@@ -50,19 +50,19 @@ const viewSubmenu = [
 		}
 	},
 	{
-		label: 'Toggle Dark Mode',
-		accelerator: 'CmdOrCtrl+D',
-		click() {
-			sendAction('toggle-dark-mode');
-		}
-	},
-	{
 		label: 'Show Message Buttons',
 		type: 'checkbox',
 		checked: config.get('showMessageButtons'),
 		click() {
 			config.set('showMessageButtons', !config.get('showMessageButtons'));
 			sendAction('toggle-message-buttons');
+		}
+	},
+	{
+		label: 'Toggle Dark Mode',
+		accelerator: 'CmdOrCtrl+D',
+		click() {
+			sendAction('toggle-dark-mode');
 		}
 	}
 ];


### PR DESCRIPTION
This commit suggests to hide options in message box (insert emoji,
image, git...) and show them with hover over like/send button. This
would make interface clean without removing those options.

Fixes #355