### PR TITLE
Fix video player width

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -103,6 +103,26 @@ html.sidebar-hidden ._1enh {
 	display: none;
 }
 
+/* Message box: fix video width */
+._3zvs._5z-5 {
+	width: 100% !important;
+}
+._2poz._52mr._ui9._2n8h._2n8i._5fk1 {
+	width: 100% !important;
+}
+._ccq._4tsk._3o67._52mr._4-od {
+	width: 100% !important;
+}
+._1c_u {
+	width: 100% !important;
+}
+._53j5 {
+	width: 100% !important;
+}
+._ox1._21y0 {
+	width: 100% !important;
+}
+
 /* Move the contextual back button so it's not obstructed by the native traffic lights */
 ._30yy._2oc9 {
 	margin-left: 65px !important;


### PR DESCRIPTION
Video player width is fixed and it is not resized when the window gets
too small. This fix will resize it when window size is changed.