### PR TITLE
Fix mute notifications not saved

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -92,7 +92,7 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 		notificationCheckbox.click();
 	}
 
-	ipc.send('mute-notifications-toggled', !notificationCheckbox.checked);
+	ipc.send('mute-notifications-toggled', notificationCheckbox.checked);
 
 	if (!wasPreferencesOpen) {
 		closePreferences();


### PR DESCRIPTION
When notifications are enabled the setting is not saved and on each
start of Caprine notifications are disabled. This fixes it.

Fixes: https://github.com/sindresorhus/caprine/issues/369
Fixes: https://github.com/sindresorhus/caprine/issues/381