### PR TITLE
Fix group-chat name text color in dark mode (#383)

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -322,7 +322,8 @@ html.dark-mode ._1li- {
 }
 
 /* Right sidebar: group chat names */
-html.dark-mode ._2jnv {
+html.dark-mode ._2jnv,
+html.dark-mode ._5rpu {
 	color: var(--base-seventy);
 }
 


### PR DESCRIPTION
This prevents the group conversation name from turning black while renaming the conversation.