### PR TITLE
Fixed back button margin

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -123,11 +123,6 @@ html.sidebar-hidden ._1enh {
 	width: 100% !important;
 }
 
-/* Move the contextual back button so it's not obstructed by the native traffic lights */
-._30yy._2oc9 {
-	margin-left: 65px !important;
-}
-
 @media all and (max-width: 700px) {
 	/* Make right column flexible in compact mode */
 	._1q5- {

--- a/browser.js
+++ b/browser.js
@@ -77,6 +77,17 @@ function setSidebarVisibility() {
 	ipc.send('set-sidebar-visibility');
 }
 
+ipc.on('set-back-button-margin', (event, defaultStatus) => {
+	// Workaround for slow load of button element
+	setTimeout(() => {
+		if (defaultStatus) {
+			document.getElementsByClassName('_30yy _2oc9')[0].style.marginLeft = '65px !important';
+		} else {
+			document.getElementsByClassName('_30yy _2oc9')[0].style.marginLeft = '0 !important';
+		}
+	}, 1000);
+});
+
 ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 	const wasPreferencesOpen = isPreferencesOpen();
 

--- a/index.js
+++ b/index.js
@@ -285,6 +285,8 @@ app.on('ready', () => {
 			mainWindow.show();
 		}
 
+		mainWindow.webContents.send('set-back-button-margin', process.platform === 'darwin');
+
 		mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
 	});
 


### PR DESCRIPTION
Added event for setting margin if platform is darwin, otherwise the
margin is set to 0. Also removed original style from `browser.css` for
margin because it breaks this setting. There is a problem that page
loads too slow and js returns empty HTMLCollection so I've added a
workaround for it with `setTimeout` function.

Closes: https://github.com/sindresorhus/caprine/issues/395