### PR TITLE
Fix dark mode transparency issue with the conversation contact list dropdown

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -380,7 +380,7 @@ html.dark-mode ._2zn6 {
 
 /* New conversation contact list: popup */
 html.dark-mode ._2y8_ {
-	background: transparent;
+	background-color: var(--container-color);
 	border: solid 1px var(--base-five);
 }
 


### PR DESCRIPTION
Uses the container color as background color for the conversation contact list dropdown.

Fixes #397