### PR TITLE
Fix rich media integration name in dark mode

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -634,3 +634,8 @@ html.dark-mode ._5pw6{
 html.dark-mode ._5pw1 {
     background: var(--base-nine);
 }
+
+/* Rich media integration text */
+html.dark-mode ._29ey {
+	color: var(--base-fourty) !important;
+}


### PR DESCRIPTION
I used the same text color used pretty much everywhere else in dark mode, not sure something else should be used.

![before](https://user-images.githubusercontent.com/2040807/36945244-5e67f238-1fab-11e8-9482-6ecbb06cf714.png)
![after](https://user-images.githubusercontent.com/2040807/36945246-5fdd9f1e-1fab-11e8-95ed-e76cbb71c152.png)

