### PR TITLE
Fix admin label in dark mode

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -327,6 +327,11 @@ html.dark-mode ._5rpu {
 	color: var(--base-seventy);
 }
 
+/* Right sidebar: group chat names admin label */
+html.dark-mode ._5qsj {
+	color: var(--base-fourty);
+}
+
 /* Right sidebar: messenger type info under name */
 html.dark-mode ._3eus {
 	color: var(--base-fourty);


### PR DESCRIPTION
Fixed admin label next to members names in group chat so it's light in
dark mode.