### PR TITLE
Added emoji color config

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,6 @@
 'use strict';
 const electron = require('electron');
+const elementReady = require('element-ready');
 const config = require('./config');
 
 const {ipcRenderer: ipc} = electron;
@@ -93,6 +94,20 @@ ipc.on('toggle-mute-notifications', (event, defaultStatus) => {
 	}
 
 	ipc.send('mute-notifications-toggled', notificationCheckbox.checked);
+
+	if (!wasPreferencesOpen) {
+		closePreferences();
+	}
+});
+
+ipc.on('set-emoji-color', async (event, defaultStatus) => {
+	const wasPreferencesOpen = isPreferencesOpen();
+
+	if (!wasPreferencesOpen) {
+		openPreferences();
+	}
+
+	(await elementReady(`._51mx td:nth-child(${defaultStatus + 1}) ._4rlu`)).click();
 
 	if (!wasPreferencesOpen) {
 		closePreferences();
@@ -329,3 +344,25 @@ document.addEventListener('keydown', event => {
 		jumpToConversation(num);
 	}
 });
+
+// Add event listener to catch a change of emoji color
+(async function () {
+	(await elementReady('._51mx td:nth-child(1) ._4rlu')).addEventListener('click', () => {
+		config.set('emojiColor', 0);
+	});
+	(await elementReady('._51mx td:nth-child(1) ._4rlu')).addEventListener('click', () => {
+		config.set('emojiColor', 1);
+	});
+	(await elementReady('._51mx td:nth-child(1) ._4rlu')).addEventListener('click', () => {
+		config.set('emojiColor', 2);
+	});
+	(await elementReady('._51mx td:nth-child(1) ._4rlu')).addEventListener('click', () => {
+		config.set('emojiColor', 3);
+	});
+	(await elementReady('._51mx td:nth-child(1) ._4rlu')).addEventListener('click', () => {
+		config.set('emojiColor', 4);
+	});
+	(await elementReady('._51mx td:nth-child(1) ._4rlu')).addEventListener('click', () => {
+		config.set('emojiColor', 5);
+	});
+})();

--- a/config.js
+++ b/config.js
@@ -23,6 +23,7 @@ module.exports = new Store({
 		useWorkChat: false,
 		sidebarHidden: false,
 		autoHideMenuBar: false,
-		notificationsMuted: false
+		notificationsMuted: false,
+		emojiColor: 2
 	}
 });

--- a/index.js
+++ b/index.js
@@ -286,6 +286,7 @@ app.on('ready', () => {
 		}
 
 		mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
+		mainWindow.webContents.send('set-emoji-color', config.get('emojiColor'));
 	});
 
 	webContents.on('new-window', (event, url, frameName, disposition, options) => {


### PR DESCRIPTION
I've added event listeners for buttons of emoji colors in preferences. This will save the settings and set saved emoji color on startup.
This PR requires https://github.com/sindresorhus/caprine/pull/420 because it fixes the problem when setting saved config on startup.