### PR TITLE
Fix mute notifications

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -115,7 +115,7 @@ ipc.on('toggle-mute-notifications', async (event, defaultStatus) => {
 
 	if (defaultStatus === undefined) {
 		notificationCheckbox.click();
-	} else if ((defaultStatus && !notificationCheckbox.checked) || (!defaultStatus && notificationCheckbox.checked)) {
+	} else if ((defaultStatus && notificationCheckbox.checked) || (!defaultStatus && !notificationCheckbox.checked)) {
 		notificationCheckbox.click();
 	}
 


### PR DESCRIPTION
Config variable `notificationsMuted` is true if notifications should be
muted, not unmuted. There was a bug in if statement in `browser.js` when
it checks config state and real state.

Closes: #437 