### PR TITLE
Remove left and right padding in touch bar buttons

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -368,19 +368,25 @@ function urlToCanvas(url, size) {
 		img.crossOrigin = 'anonymous';
 		img.addEventListener('load', () => {
 			const canvas = document.createElement('canvas');
-			const padding = 6;
-			canvas.width = size;
-			canvas.height = size;
+			const padding = {
+				top: 3,
+				right: 0,
+				bottom: 3,
+				left: 0
+			};
+
+			canvas.width = size + padding.left + padding.right;
+			canvas.height = size + padding.top + padding.bottom;
 
 			const ctx = canvas.getContext('2d');
 
 			ctx.save();
 			ctx.beginPath();
-			ctx.arc(size / 2, size / 2, (size - padding) / 2, 0, Math.PI * 2, true);
+			ctx.arc((size / 2) + padding.left, (size / 2) + padding.top, size / 2, 0, Math.PI * 2, true);
 			ctx.closePath();
 			ctx.clip();
 
-			ctx.drawImage(img, padding / 2, padding / 2, size - padding, size - padding);
+			ctx.drawImage(img, padding.left, padding.top, size, size);
 
 			ctx.restore();
 
@@ -401,8 +407,7 @@ function getDataUrlFromImg(img, unread) {
 			return resolve(img.dataUnreadUrl);
 		}
 
-		const canvasSize = 30;
-		const canvas = await urlToCanvas(img.src, canvasSize);
+		const canvas = await urlToCanvas(img.src, 30);
 		const ctx = canvas.getContext('2d');
 		img.dataUrl = canvas.toDataURL();
 
@@ -413,7 +418,7 @@ function getDataUrlFromImg(img, unread) {
 		const markerSize = 6;
 		ctx.fillStyle = '#f42020';
 		ctx.beginPath();
-		ctx.ellipse(canvasSize - markerSize, markerSize, markerSize, markerSize, 0, 0, 2 * Math.PI);
+		ctx.ellipse(canvas.width - markerSize, markerSize, markerSize, markerSize, 0, 0, 2 * Math.PI);
 		ctx.fill();
 		img.dataUnreadUrl = canvas.toDataURL();
 		resolve(img.dataUnreadUrl);

--- a/browser.js
+++ b/browser.js
@@ -415,7 +415,7 @@ function getDataUrlFromImg(img, unread) {
 			return resolve(img.dataUrl);
 		}
 
-		const markerSize = 6;
+		const markerSize = 8;
 		ctx.fillStyle = '#f42020';
 		ctx.beginPath();
 		ctx.ellipse(canvas.width - markerSize, markerSize, markerSize, markerSize, 0, 0, 2 * Math.PI);


### PR DESCRIPTION
Decrease the indentations to the left and to the right. Thus, the image area became more compact, which made it possible to slightly increase the resolution of the image

Before:
![tg_image_4091352590](https://user-images.githubusercontent.com/1662812/39519029-cf22916e-4e0d-11e8-905f-265971ebedae.jpeg)
After:
![image](https://user-images.githubusercontent.com/1662812/39519707-9578d812-4e10-11e8-961a-962588b274fc.png)


