### PR TITLE
Support the `flashWindowOnMessage` option on Linux too

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,10 +80,11 @@ function updateBadge(title, titlePrefix) {
 				mainWindow.webContents.send('render-overlay-icon', messageCount);
 			}
 		}
+	}
 
-		if (config.get('flashWindowOnMessage')) {
-			mainWindow.flashFrame(messageCount !== 0);
-		}
+	if (config.get('flashWindowOnMessage')) {
+		console.log(messageCount);
+		mainWindow.flashFrame(messageCount !== 0);
 	}
 }
 

--- a/menu.js
+++ b/menu.js
@@ -496,7 +496,6 @@ const otherTpl = [
 			{
 				type: 'checkbox',
 				label: 'Flash Window on Message',
-				visible: process.platform === 'win32',
 				checked: config.get('flashWindowOnMessage'),
 				click(item) {
 					config.set('flashWindowOnMessage', item.checked);


### PR DESCRIPTION
Resolves #435.
As flashFrame is now platform agnostic (https://electronjs.org/docs/all#winflashframeflag).

Verified it worked on Ubuntu 18.04 i3wm.