### PR TITLE
Update class name for app drag region

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -22,7 +22,8 @@ body {
 
 /* Bind the toolbar as the window's draggable region */
 ._36ic._5l-3,
-._5742, ._673w {
+._5742,
+._673w {
 	-webkit-app-region: drag;
 }
 

--- a/browser.css
+++ b/browser.css
@@ -22,7 +22,7 @@ body {
 
 /* Bind the toolbar as the window's draggable region */
 ._36ic._5l-3,
-._5742 {
+._5742, ._673w {
 	-webkit-app-region: drag;
 }
 


### PR DESCRIPTION
Looks like Facebook changed the class names (they seem to be using some sort of build tool that renames classes) which broke app dragging (fixes #410). This PR adds the class name Facebook is currently using for the relevant element, and resolves the dragging issue.