### PR TITLE
Fix the `New Conversation` button overlapping the traffic light controls on macOS

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -164,6 +164,10 @@ html.sidebar-hidden ._1enh {
 	._4_j5 {
 		display: none !important;
 	}
+	
+	._36ic._5l-3 {
+		margin-top: 30px;
+	}
 }
 
 /* Don't show outline on clickable elements except in the delete/mute modal so that we know what we are selecting */

--- a/browser.css
+++ b/browser.css
@@ -165,6 +165,7 @@ html.sidebar-hidden ._1enh {
 		display: none !important;
 	}
 	
+	/* Fix the overlapping `New Conversation` button on the  window control panel */
 	._36ic._5l-3 {
 		margin-top: 30px;
 	}

--- a/browser.css
+++ b/browser.css
@@ -166,7 +166,7 @@ html.sidebar-hidden ._1enh {
 	}
 	
 	/* Fix the `New Conversation` button overlapping the traffic light controls on macOS */
-	._36ic._5l-3 {
+	html.os-darwin ._36ic._5l-3 {
 		margin-top: 30px;
 	}
 }

--- a/browser.css
+++ b/browser.css
@@ -165,7 +165,7 @@ html.sidebar-hidden ._1enh {
 		display: none !important;
 	}
 	
-	/* Fix the overlapping `New Conversation` button on the  window control panel */
+	/* Fix the `New Conversation` button overlapping the traffic light controls on macOS */
 	._36ic._5l-3 {
 		margin-top: 30px;
 	}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1662812/40649358-68ceabfa-6339-11e8-8039-9ddc244eef43.png)
After
![image](https://user-images.githubusercontent.com/1662812/40649455-a4b2cdfe-6339-11e8-98d6-ba0b0204aaf0.png)
