### PR TITLE
Update build docs link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ $ npm install && npm start
 
 ### Build
 
-See the [`electron-builder` docs](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build).
+See the [`electron-builder` docs](https://www.electron.build/multi-platform-build).
 
 ### Publish
 


### PR DESCRIPTION
electron-builder updated their docs, presenting the user with:
>Moved to [Multi Platform Build](https://www.electron.build/multi-platform-build) on [electron.build](https://electron.build/configuration/configuration) site.

This commit updates the link to point to the link the old wiki tells you to go to.