### PR TITLE
Don’t show the main window on conversations change

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,6 @@ app.on('ready', () => {
 				return;
 			}
 
-			mainWindow.show();
 			const items = conversations.map(({label, icon}, index) => {
 				return {
 					label: `${label}`,


### PR DESCRIPTION
Fixes #483 (a bug introduced in #470)

I don't think there's any reason to display the window on any change in the conversations list.