### PR TITLE
Fix unread conversation timestamp color

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -296,6 +296,9 @@ html.dark-mode ._4g0h {
 html.dark-mode ._1ht3 {
 	background: var(--unread-bg) !important;
 }
+html.dark-mode ._1ht3 ._1ht7.timestamp {
+	color: var(--base-twenty);
+}
 
 /* Right sidebar */
 html.dark-mode ._4_j5 {


### PR DESCRIPTION
Changed color of the timestamp in contact list so it would match all
other because the background color of contact is now used as an
indicator if messages are read or not, the blue color of a timestamp is
not needed anymore.