### PR TITLE
Let Ctrl+1..Ctrl+9 work for Azerty keyboards too

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -469,7 +469,7 @@ document.addEventListener('keydown', event => {
 		previousConversation();
 	}
 
-	const num = parseInt(event.key, 10);
+	const num = parseInt(event.code.slice(-1), 10);
 
 	if (num >= 1 && num <= 9) {
 		jumpToConversation(num);


### PR DESCRIPTION
To make Ctrl+1 till Ctrl+9 work with Azerty keyboard layouts, without needing to use the shift key every time, I created this simple pull request.

event.code contains either:
* Digit1..Digit9
* Numpad1..Numpad9

Getting the last character from the string should be a number, so we check that number.

I think this change is rather trivial and I would love to see it in a new release of Caprine.