### PR TITLE
Don't hide the right sidebar in compact mode

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -161,11 +161,6 @@ html.sidebar-hidden ._1enh {
 		display: none !important;
 	}
 
-	/* Hide right sidebar in compact mode */
-	._4_j5 {
-		display: none !important;
-	}
-
 	/* Fix the `New Conversation` button overlapping the traffic light controls on macOS */
 	html.os-darwin ._36ic._5l-3 {
 		margin-top: 30px;


### PR DESCRIPTION
I think it's a mistake to forcibly hide the right panel in compact mode.
This prevents users from accessing some important features, such as viewing attachments, discussion settings, and more.
It's best to leave the right panel visibility at the discretion of each individual user.