### PR TITLE
Fix a couple of visual bugs in compact mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 yarn.lock
 /dist
+
+\.DS_Store
+
+\.vscode/

--- a/browser.css
+++ b/browser.css
@@ -97,7 +97,7 @@ html.sidebar-hidden ._1enh {
 }
 
 /* Moves text to the left when window width < 473px */
-._673w ._17w2{
+._673w ._17w2 {
 	display: block !important;
 }
 

--- a/browser.css
+++ b/browser.css
@@ -33,6 +33,11 @@ body {
 	overflow-y: initial;
 }
 
+/* The message buttons are always in one row */
+._4rv4 > div {
+	display: flex;
+}
+
 /* Exclude `New Messages`, `Voice Call`, `Video Call` & `Conversation Info` buttons from the draggable region */
 ._36ic._5l-3 ._30yy,
 ._5742 ._30yy,

--- a/browser.css
+++ b/browser.css
@@ -91,10 +91,9 @@ html.sidebar-hidden ._1enh {
 	display: none;
 }
 
-/* Center names in titlebar */
-._5742,
-._673w {
-	text-align: center !important;
+/* Moves text to the left when window width < 473px */
+._673w ._17w2{
+	display: block !important;
 }
 
 /* Narrower titlebar */


### PR DESCRIPTION
1. Fixed: when the window is very narrow then the text in the header overlaps with buttons
2. Fixed: when the window is very narrow then the buttons near the text box fall into two rows

Fixes #529