### PR TITLE
Fixed sound/notifications option saving

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -110,7 +110,7 @@ ipc.on('toggle-mute-notifications', async (event, defaultStatus) => {
 		await openPreferences();
 	}
 
-	const notificationCheckbox = document.querySelector('._374b:nth-of-type(3) ._4ng2 input');
+	const notificationCheckbox = document.querySelector('._374b:nth-of-type(4) ._4ng2 input');
 
 	if (defaultStatus === undefined) {
 		notificationCheckbox.click();


### PR DESCRIPTION
Due to recent changes to preferences dialog and new options added order
of options was changed and that caused `Mute notifications` option to
change sound setting instead of notificaions setting.

Closes: https://github.com/sindresorhus/caprine/issues/519