### PR TITLE
Update overflow scrolling rule to !important

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -30,7 +30,7 @@ body {
 
 /* Fix broken scroll arrows on mesage input on Windows */
 ._kmc {
-	overflow-y: initial;
+	overflow-y: hidden !important;
 }
 
 /* Exclude `New Messages`, `Voice Call`, `Video Call` & `Conversation Info` buttons from the draggable region */


### PR DESCRIPTION
https://github.com/sindresorhus/caprine/issues/490

While the inline fix in Chrome worked, the Electron version needs an `!important` tag to override. Update to https://github.com/sindresorhus/caprine/pull/153