### PR TITLE
Update badge on conversations change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 node_modules
 yarn.lock
 /dist
-
-\.vscode/
-
-\.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 yarn.lock
 /dist
+
+\.vscode/
+
+\.DS_Store

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ function updateBadge(conversations) {
 	if (!Array.isArray(conversations)) {
 		return;
 	}
-	
-	let messageCount = conversations.filter(({unread}) => unread).length
+
+	const messageCount = conversations.filter(({unread}) => unread).length;
 
 	if (process.platform === 'darwin' || process.platform === 'linux') {
 		if (config.get('showUnreadBadge')) {
@@ -166,7 +166,6 @@ function createMainWindow() {
 	const isDarkMode = config.get('darkMode');
 	// Messenger or Work Chat
 	const mainURL = config.get('useWorkChat') ? 'https://work.facebook.com/chat' : 'https://www.messenger.com/login/';
-	const titlePrefix = config.get('useWorkChat') ? 'Workplace Chat' : 'Messenger';
 
 	const win = new electron.BrowserWindow({
 		title: app.getName(),
@@ -261,7 +260,6 @@ app.on('ready', () => {
 
 		// Update bage on conversations change
 		ipcMain.on('conversations', (event, conversations) => updateBadge(conversations));
-		
 	}
 
 	enableHiresResources();

--- a/index.js
+++ b/index.js
@@ -52,14 +52,13 @@ if (isAlreadyRunning) {
 	app.quit();
 }
 
-function updateBadge(title, titlePrefix) {
+function updateBadge(conversations) {
 	// ignore `Sindre messaged you` blinking
-	if (title.indexOf(titlePrefix) === -1) {
+	if (!Array.isArray(conversations)) {
 		return;
 	}
-
-	let messageCount = (/\((\d+)\)/).exec(title);
-	messageCount = messageCount ? Number(messageCount[1]) : 0;
+	
+	let messageCount = conversations.filter(({unread}) => unread).length
 
 	if (process.platform === 'darwin' || process.platform === 'linux') {
 		if (config.get('showUnreadBadge')) {
@@ -214,11 +213,6 @@ function createMainWindow() {
 		}
 	});
 
-	win.on('page-title-updated', (e, title) => {
-		e.preventDefault();
-		updateBadge(title, titlePrefix);
-	});
-
 	win.on('focus', () => {
 		if (config.get('flashWindowOnMessage')) {
 			// This is a security in the case where messageCount is not reset by page title update
@@ -264,6 +258,10 @@ app.on('ready', () => {
 			});
 			app.dock.setMenu(electron.Menu.buildFromTemplate([firstItem, {type: 'separator'}, ...items]));
 		});
+
+		// Update bage on conversations change
+		ipcMain.on('conversations', (event, conversations) => updateBadge(conversations));
+		
 	}
 
 	enableHiresResources();

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ app.on('ready', () => {
 			app.dock.setMenu(electron.Menu.buildFromTemplate([firstItem, {type: 'separator'}, ...items]));
 		});
 
-		// Update bage on conversations change
+		// Update badge on conversations change
 		ipcMain.on('conversations', (event, conversations) => updateBadge(conversations));
 	}
 


### PR DESCRIPTION
Previously, the change of the badge was dependent on the title of the window. Now the badge depends on the number of unreadable dialogs directly in the DOM.
