### PR TITLE
Hiding mute notifications option from preferences

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -151,6 +151,11 @@ html.sidebar-hidden ._1enh {
 	display: none !important;
 }
 
+/* Preferences dialog: hide unnecessary options */
+._374b:nth-child(5) {
+	display: none !important;
+}
+
 /* macOS: Move the contextual back button so it's not obstructed by the native traffic lights */
 .os-darwin ._30yy._2oc9 {
 	margin-left: 65px !important;


### PR DESCRIPTION
It's decided to hide mute notifications option from preferences since there has been a confusion should menu bar options be used or preferences option. Preferences option is not saved for next sessions like menu bar option is. This enforces use of menu bar option.

Fixes: https://github.com/sindresorhus/caprine/issues/498