### PR TITLE
Fix broken scroll arrows on message input

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -30,7 +30,7 @@ body {
 
 /* Fix broken scroll arrows on mesage input on Windows */
 ._kmc {
-	overflow-y: hidden !important;
+	overflow: hidden;
 }
 
 /* The message buttons are always in one row */


### PR DESCRIPTION
when resizing the window, under 860px the arrows in message input appear and the design seems off.