### PR TITLE
Fixed selected tab color in emoji picker

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -151,6 +151,11 @@ html.sidebar-hidden ._1enh {
 	display: none !important;
 }
 
+/* Message box: emoji picker selected tab */
+._1uwz._1uwx {
+	border-radius: 4pt;
+}
+
 /* Preferences dialog: hide unnecessary options */
 ._374b:nth-child(5) {
 	display: none !important;

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -96,6 +96,12 @@ html.dark-mode ._2wy4 {
 	color: var(--base-twenty);
 }
 
+/* Message list: emoji picker selected tab */
+html.dark-mode ._1uwz._1uwx {
+	background: var(--base-ten);
+	border-radius: 4pt;
+}
+
 /* Message list: timestamp */
 html.dark-mode ._497p {
 	color: var(--base-fourty);


### PR DESCRIPTION
The selected tab color is fixed and in dark mode. Also I've added
rounded corners on selected tab so it would look nicer since corners
used to be pointy.

Closes: https://github.com/sindresorhus/caprine/issues/544