### PR TITLE
enter selects first result in search

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -232,6 +232,21 @@ function jumpToConversation(key) {
 	selectConversation(index);
 }
 
+function selectFirstOption(inputField) {
+	if (!inputField || !inputField.placeholder) { return }
+	if (inputField.placeholder.includes('GIF')) {
+		let firstGif = document.querySelector('._358')
+		if (firstGif) {
+			firstGif.click()
+		}
+	} else if (inputField.placeholder.includes('Messenger')) {
+		let firstSearchResult = document.querySelector('._4ld- > img')
+		if (firstSearchResult) {
+			firstSearchResult.click()
+		}
+	}
+}
+
 // Focus on the conversation with the given index
 function selectConversation(index) {
 	document.querySelector(listSelector).children[index].firstChild.firstChild.click();
@@ -454,6 +469,10 @@ window.addEventListener('load', () => {
 // so this needs to be done the old-school way
 document.addEventListener('keydown', event => {
 	const combineKey = process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
+
+	if (event.key === 'Enter' && document.activeElement && document.activeElement.className === '_58al') {
+		selectFirstOption(document.activeElement);
+	}
 
 	if (!combineKey) {
 		return;

--- a/browser.js
+++ b/browser.js
@@ -472,7 +472,8 @@ window.addEventListener('load', () => {
 document.addEventListener('keydown', event => {
 	const combineKey = process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
 
-	if (event.key === 'Enter' && document.activeElement && document.activeElement.className === '_58al') {
+	const searchInputField = '_58al'
+	if (event.key === 'Enter' && document.activeElement && document.activeElement.className === searchInputField) {
 		selectFirstOption(document.activeElement);
 	}
 

--- a/browser.js
+++ b/browser.js
@@ -233,16 +233,18 @@ function jumpToConversation(key) {
 }
 
 function selectFirstOption(inputField) {
-	if (!inputField || !inputField.placeholder) { return }
+	if (!inputField || !inputField.placeholder) {
+		return;
+	}
 	if (inputField.placeholder.includes('GIF')) {
-		let firstGif = document.querySelector('._358')
+		const firstGif = document.querySelector('._358');
 		if (firstGif) {
-			firstGif.click()
+			firstGif.click();
 		}
 	} else if (inputField.placeholder.includes('Messenger')) {
-		let firstSearchResult = document.querySelector('._4ld- > img')
+		const firstSearchResult = document.querySelector('._4ld- > img');
 		if (firstSearchResult) {
-			firstSearchResult.click()
+			firstSearchResult.click();
 		}
 	}
 }


### PR DESCRIPTION
Currently, Enter in the search field isn't useful because the search refreshes on keydown, it should instead select the first search result. This also applies to the GIF picker.