### PR TITLE
fixed notification icon for windows & linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,10 +256,10 @@ app.on('ready', () => {
 			});
 			app.dock.setMenu(electron.Menu.buildFromTemplate([firstItem, {type: 'separator'}, ...items]));
 		});
-
-		// Update badge on conversations change
-		ipcMain.on('conversations', (event, conversations) => updateBadge(conversations));
 	}
+
+	// Update badge on conversations change
+	ipcMain.on('conversations', (event, conversations) => updateBadge(conversations));
 
 	enableHiresResources();
 


### PR DESCRIPTION
Tray icon/badge is no longer updated on any other platform than darwin. This was introduced by commit a281594b5f975833ff736573a08dd2a4bf7745f3.

Event registration for updating tray icon was moved to darwin specific condition - this is wrong. It should be registered for all platforms. This commit fixes this issue and enables icon to be update on notification  for all platforms. Fixes #578 
