### PR TITLE
[Dark Mode] Fix un-contrasting group chat more people read indicator

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -209,6 +209,12 @@ html.dark-mode ._5pd7 {
 	background: var(--base-seventy) !important;
 }
 
+/* Messages list: more people read (group chat) */
+html.dark-mode ._jf4 ._jf3 {
+	background-color: var(--base-five) !important;
+	color: var(--base-fourty) !important;
+}
+
 /* Contact list: header above */
 html.dark-mode ._36ic {
 	background: var(--list-header-color) !important;


### PR DESCRIPTION
I fixed the CSS for this thingie:

Vanilla:
<img width="95" alt="screenshot 2018-09-26 at 22 10 42" src="https://user-images.githubusercontent.com/428060/46103654-0a060c80-c1da-11e8-9cd8-e62b8dab959a.png">
Dark mode before:
<img width="82" alt="screenshot 2018-09-26 at 22 10 33" src="https://user-images.githubusercontent.com/428060/46103665-14c0a180-c1da-11e8-9157-647de13c3e87.png">
Dark mode after:
<img width="93" alt="screenshot 2018-09-26 at 22 11 34" src="https://user-images.githubusercontent.com/428060/46103674-18ecbf00-c1da-11e8-9912-d92afbc27c6f.png">
