### PR TITLE
Add installation instructions for Arch Linux to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ Or with [Homebrew-Cask](https://caskroom.github.io): `$ brew cask install caprin
 
 [**Download**](https://github.com/sindresorhus/caprine/releases/latest) the `.AppImage` or `.deb` file.
 
+Arch Linux: `pacman -S caprine`
+
 Also available as a [snap](https://snapcraft.io/caprine).
 
 *The AppImage needs to be [made executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80) after download.*


### PR DESCRIPTION
Caprine is available from the [community repository](https://www.archlinux.org/packages/community/any/caprine/).