### PR TITLE
Re-enable vibrancy support for macOS users

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -148,13 +148,13 @@ ipc.on('toggle-unread-threads-view', () => {
 
 function setDarkMode() {
 	document.documentElement.classList.toggle('dark-mode', config.get('darkMode'));
-	/// ipc.send('set-vibrancy');
+	ipc.send('set-vibrancy');
 }
 
-/// function setVibrancy() {
-// 	document.documentElement.classList.toggle('vibrancy', config.get('vibrancy'));
-// 	ipc.send('set-vibrancy');
-// }
+function setVibrancy() {
+	document.documentElement.classList.toggle('vibrancy', config.get('vibrancy'));
+	ipc.send('set-vibrancy');
+}
 
 function renderOverlayIcon(messageCount) {
 	const canvas = document.createElement('canvas');
@@ -182,12 +182,12 @@ ipc.on('set-dark-mode', setDarkMode);
 
 // Disabled because of https://github.com/electron/electron/issues/10886
 // and other vibrancy bugs with Electron v2
-/// ipc.on('toggle-vibrancy', () => {
-// 	config.set('vibrancy', !config.get('vibrancy'));
-// 	setVibrancy();
+ipc.on('toggle-vibrancy', () => {
+	config.set('vibrancy', !config.get('vibrancy'));
+	setVibrancy();
 
-// 	document.documentElement.style.backgroundColor = 'transparent';
-// });
+	document.documentElement.style.backgroundColor = 'transparent';
+});
 
 ipc.on('render-overlay-icon', (event, messageCount) => {
 	ipc.send('update-overlay-icon', renderOverlayIcon(messageCount).toDataURL(), String(messageCount));
@@ -444,7 +444,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	// Activate vibrancy effect if it was set before quitting
-	// setVibrancy();
+	setVibrancy();
 });
 
 window.addEventListener('load', () => {

--- a/menu.js
+++ b/menu.js
@@ -125,13 +125,13 @@ ${process.platform} ${process.arch} ${os.release()}`;
 ];
 
 if (process.platform === 'darwin') {
-	/// viewSubmenu.push({
-	// 	label: 'Toggle Vibrancy',
-	// 	position: 'endof=toggle',
-	// 	click() {
-	// 		sendAction('toggle-vibrancy');
-	// 	}
-	// });
+	viewSubmenu.push({
+		label: 'Toggle Vibrancy',
+		position: 'endof=toggle',
+		click() {
+			sendAction('toggle-vibrancy');
+		}
+	});
 } else {
 	helpSubmenu.push({
 		type: 'separator'

--- a/vibrancy.css
+++ b/vibrancy.css
@@ -20,7 +20,8 @@ html.vibrancy ._673w {
 }
 
 /* Share previews: title and subtitle */
-html.vibrancy .__6k, html.vibrancy .__6l {
+html.vibrancy .__6k,
+html.vibrancy .__6l {
 	background-color: transparent !important;
 }
 

--- a/vibrancy.css
+++ b/vibrancy.css
@@ -14,6 +14,16 @@ html.vibrancy ._5iwm ._58al {
 	background-color: rgba(246, 247, 249, 0.5) !important;
 }
 
+/* Chat title bar */
+html.vibrancy ._673w {
+	background-color: transparent !important;
+}
+
+/* Share previews: title and subtitle */
+html.vibrancy .__6k, html.vibrancy .__6l {
+	background-color: transparent !important;
+}
+
 /* Contact list: person container */
 html.vibrancy ._1qt4 {
 	border-top: solid 1px rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
Since Caprine is now using Electron version 3, I wonder if the rendering bugs are gone and it is safe to re-enable vibrancy support for macOS users? I haven't noticed any graphical artifacts from enabling dark mode and vibrancy as of now, so I've submitted this PR in case it's okay to re-enable vibrancy.

I've also added some selectors to make the chat's title bar and the shared link's preview transparent.