### PR TITLE
Add an option to disable hardware acceleration

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,6 +3,7 @@ const Store = require('electron-store');
 
 module.exports = new Store({
 	defaults: {
+		hardwareAcceleration: true,
 		darkMode: false,
 		vibrancy: false,
 		zoomFactor: 1,

--- a/config.js
+++ b/config.js
@@ -3,7 +3,6 @@ const Store = require('electron-store');
 
 module.exports = new Store({
 	defaults: {
-		hardwareAcceleration: true,
 		darkMode: false,
 		vibrancy: false,
 		zoomFactor: 1,
@@ -25,6 +24,7 @@ module.exports = new Store({
 		useWorkChat: false,
 		sidebarHidden: false,
 		autoHideMenuBar: false,
-		notificationsMuted: false
+		notificationsMuted: false,
+		hardwareAcceleration: true
 	}
 });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ const {app, ipcMain, Menu, nativeImage, Notification} = electron;
 
 app.setAppUserModelId('com.sindresorhus.caprine');
 
+if (!config.get('hardwareAcceleration')) {
+	app.disableHardwareAcceleration();
+}
+
 if (!isDev) {
 	autoUpdater.logger = log;
 	autoUpdater.logger.transports.file.level = 'info';

--- a/menu.js
+++ b/menu.js
@@ -212,6 +212,14 @@ const macosTpl = [
 				}
 			},
 			{
+				label: 'Hardware Acceleration (after restart)',
+				type: 'checkbox',
+				checked: config.get('hardwareAcceleration'),
+				click() {
+					config.set('hardwareAcceleration', !config.get('hardwareAcceleration'));
+				}
+			},
+			{
 				label: 'Preferences…',
 				accelerator: 'Cmd+,',
 				click() {

--- a/menu.js
+++ b/menu.js
@@ -212,7 +212,7 @@ const macosTpl = [
 				}
 			},
 			{
-				label: 'Hardware Acceleration (after restart)',
+				label: 'Hardware Acceleration (requires restart)',
 				type: 'checkbox',
 				checked: config.get('hardwareAcceleration'),
 				click() {


### PR DESCRIPTION
There is some demand to disable hardware acceleration to prevent electron from kicking GPUs into high-performance modes (effectively using a lot more energy).

This change adds a new menu option that toggles a config value to disable the hardware acceleration. By default, the hardware acceleration is enabled to stay parity with the current behaviour.

-----

There is some concern around rendering artifacts as mentioned in #469, although some reports are indicating with the recent build they aren't present.

---

Fix #469