### PR TITLE
Change close window behaviour on macOS to the default behaviour instead of hide

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,12 +203,7 @@ function createMainWindow() {
 
 			// Workaround for electron/electron#10023
 			win.blur();
-
-			if (process.platform === 'darwin') {
-				app.hide();
-			} else {
-				win.hide();
-			}
+			win.hide();
 		}
 	});
 


### PR DESCRIPTION
Fixes #288

I'm proposing to change the app's macOS close window behaviour to be the default behaviour for closing macOS apps, which uses `win.hide()` instead of the "hide behaviour" (<kbd>Cmd</kbd><kbd>H</kbd>), which uses `app.hide()`.

I realize that this was an intentional change, and I saw the issue you opened in the Electron repo [here](https://github.com/electron/electron/issues/3694). However, I think this should be reverted for the following reasons:

1. It causes problems with window managers such as [Amethyst](https://github.com/ianyh/Amethyst). As described in #288, when using Amethyst, closing and re-opening Caprine doesn't re-render windows properly.

2. The default behaviour of all macOS apps is to have the "close behaviour" when closing an app, and the "hide behaviour" when hiding an app. However, as it stands right now, closing and hiding have the same behaviour. I'm assuming the reason why this was done in the first place was so that once the app closes, it'll focus on another app instead of keeping the focus on Caprine. While I understand that that may be useful, it's not standard and is inconsistent with the behaviour of virtually every other macOS app.