### PR TITLE
Fix decline button in dark mode

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -312,6 +312,11 @@ html.dark-mode ._1ht3 ._1ht7.timestamp {
 	color: var(--base-twenty);
 }
 
+/* Contact list: message request (decline button) */
+html.dark-mode ._3quh._30yy._17u4._3yvh._1d-z {
+	color: #f03d25;
+}
+
 /* Right sidebar */
 html.dark-mode ._4_j5 {
 	background: transparent;


### PR DESCRIPTION
Decline button is now using more visible color in dark mode as recommended.

Closes: https://github.com/sindresorhus/caprine/issues/619