### PR TITLE
Fix dark mode + vibrancy not rendering properly on restart

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -439,7 +439,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	// Prevent flash of white on startup when in dark mode
 	// TODO: find a CSS-only solution
-	if (config.get('darkMode')) {
+	if (config.get('darkMode') && !config.get('vibrancy')) {
 		document.documentElement.style.backgroundColor = '#192633';
 	}
 


### PR DESCRIPTION
Fixes #633

I'm running Caprine on Mac, and I have not experienced the white flash issue personally, but it might be an issue on other platforms. Since right now vibrancy is a macOS-only feature, I find it enough to simply apply the white flash fix if Dark mode is enabled, but not vibrancy. 