### PR TITLE
Fix notification title for group chats

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -497,6 +497,7 @@ window.Notification = (notification => {
 	const customNotification = function (title, options) {
 		let {body, icon, silent} = options;
 		body = body.props ? body.props.content[0] : body;
+		title = (typeof title === 'object' && title.props) ? title.props.content[0] : title;
 
 		const img = new Image();
 		img.crossOrigin = 'anonymous';


### PR DESCRIPTION
Fixed a bug where notifications have no title in group conversations.

Fixes #626