### PR TITLE
Fix window flash on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function updateBadge(conversations) {
 		if (config.get('showUnreadBadge')) {
 			app.setBadgeCount(messageCount);
 		}
+
 		if (is.macos && config.get('bounceDockOnMessage') && prevMessageCount !== messageCount) {
 			app.dock.bounce('informational');
 			prevMessageCount = messageCount;
@@ -79,6 +80,7 @@ function updateBadge(conversations) {
 		if (config.get('showUnreadBadge')) {
 			tray.setBadge(messageCount);
 		}
+
 		if (config.get('flashWindowOnMessage')) {
 			mainWindow.flashFrame(messageCount !== 0);
 		}

--- a/index.js
+++ b/index.js
@@ -75,8 +75,13 @@ function updateBadge(conversations) {
 		}
 	}
 
-	if ((is.linux || is.windows) && config.get('showUnreadBadge')) {
-		tray.setBadge(messageCount);
+	if (is.linux || is.windows) {
+		if (config.get('showUnreadBadge')) {
+			tray.setBadge(messageCount);
+		}
+		if (config.get('flashWindowOnMessage')) {
+			mainWindow.flashFrame(messageCount !== 0);
+		}
 	}
 
 	if (is.windows) {
@@ -87,10 +92,6 @@ function updateBadge(conversations) {
 				// Delegate drawing of overlay icon to renderer process
 				mainWindow.webContents.send('render-overlay-icon', messageCount);
 			}
-		}
-
-		if (config.get('flashWindowOnMessage')) {
-			mainWindow.flashFrame(messageCount !== 0);
 		}
 	}
 }


### PR DESCRIPTION
Caprine does not set the urgency hint for its window under Linux when a new message is received. This issue was discussed before (https://github.com/sindresorhus/caprine/issues/435). The provided change enables this behavior. Has been tested on linux (Arch + i3wm).

---

Fixes #435