### PR TITLE
Fix notifications

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -502,9 +502,11 @@ document.addEventListener('keydown', event => {
 	}
 });
 
-window.Notification = (notification => {
-	const customNotification = function (title, options) {
-		let {body, icon, silent} = options;
+// Pass events sent via `window.postMessage` on to the main process
+window.addEventListener('message', ({data: {type, data}}) => {
+	if (type === 'notification' && data) {
+		let {title, body, icon, silent} = data;
+
 		body = body.props ? body.props.content[0] : body;
 		title = (typeof title === 'object' && title.props) ? title.props.content[0] : title;
 
@@ -525,12 +527,8 @@ window.Notification = (notification => {
 
 			ipc.send('notification', {title, body, icon: canvas.toDataURL(), silent, fileName});
 		});
-
-		return false;
-	};
-
-	return Object.assign(customNotification, notification);
-})(window.Notification);
+	}
+});
 
 ipc.on('jump-to-conversation-by-img', (event, fileName) => {
 	selectConversationByImg(fileName);

--- a/browser.js
+++ b/browser.js
@@ -504,31 +504,33 @@ document.addEventListener('keydown', event => {
 
 // Pass events sent via `window.postMessage` on to the main process
 window.addEventListener('message', ({data: {type, data}}) => {
-	if (type === 'notification' && data) {
-		let {title, body, icon, silent} = data;
-
-		body = body.props ? body.props.content[0] : body;
-		title = (typeof title === 'object' && title.props) ? title.props.content[0] : title;
-
-		const img = new Image();
-		img.crossOrigin = 'anonymous';
-		img.src = icon;
-
-		img.addEventListener('load', () => {
-			const canvas = document.createElement('canvas');
-			const ctx = canvas.getContext('2d');
-
-			canvas.width = img.width;
-			canvas.height = img.height;
-
-			ctx.drawImage(img, 0, 0, img.width, img.height);
-
-			const fileName = icon.substring(icon.lastIndexOf('/') + 1, icon.indexOf('?'));
-
-			ipc.send('notification', {title, body, icon: canvas.toDataURL(), silent, fileName});
-		});
+	if (type === 'notification') {
+		showNotification(data);
 	}
 });
+
+function showNotification({title, body, icon, silent}) {
+	body = body.props ? body.props.content[0] : body;
+	title = (typeof title === 'object' && title.props) ? title.props.content[0] : title;
+
+	const img = new Image();
+	img.crossOrigin = 'anonymous';
+	img.src = icon;
+
+	img.addEventListener('load', () => {
+		const canvas = document.createElement('canvas');
+		const ctx = canvas.getContext('2d');
+
+		canvas.width = img.width;
+		canvas.height = img.height;
+
+		ctx.drawImage(img, 0, 0, img.width, img.height);
+
+		const fileName = icon.substring(icon.lastIndexOf('/') + 1, icon.indexOf('?'));
+
+		ipc.send('notification', {title, body, icon: canvas.toDataURL(), silent, fileName});
+	});
+}
 
 ipc.on('jump-to-conversation-by-img', (event, fileName) => {
 	selectConversationByImg(fileName);

--- a/browser.js
+++ b/browser.js
@@ -509,7 +509,7 @@ window.addEventListener('message', ({data: {type, data}}) => {
 	}
 });
 
-function showNotification({title, body, icon, silent}) {
+function showNotification({id, title, body, icon, silent}) {
 	body = body.props ? body.props.content[0] : body;
 	title = (typeof title === 'object' && title.props) ? title.props.content[0] : title;
 
@@ -526,17 +526,10 @@ function showNotification({title, body, icon, silent}) {
 
 		ctx.drawImage(img, 0, 0, img.width, img.height);
 
-		const fileName = icon.substring(icon.lastIndexOf('/') + 1, icon.indexOf('?'));
-
-		ipc.send('notification', {title, body, icon: canvas.toDataURL(), silent, fileName});
+		ipc.send('notification', {id, title, body, icon: canvas.toDataURL(), silent});
 	});
 }
 
-ipc.on('jump-to-conversation-by-img', (event, fileName) => {
-	selectConversationByImg(fileName);
+ipc.on('notification-callback', (event, data) => {
+	window.postMessage({type: 'notification-callback', data}, '*');
 });
-
-function selectConversationByImg(fileName) {
-	const selector = `${listSelector} img[src*="${fileName}"]`;
-	document.querySelector(selector).click();
-}

--- a/index.js
+++ b/index.js
@@ -402,7 +402,7 @@ app.on('before-quit', () => {
 	config.set('lastWindowState', mainWindow.getNormalBounds());
 });
 
-ipcMain.on('notification', (event, {title, body, icon, silent, fileName}) => {
+ipcMain.on('notification', (event, {id, title, body, icon, silent}) => {
 	const notification = new Notification({
 		title,
 		body,
@@ -410,10 +410,14 @@ ipcMain.on('notification', (event, {title, body, icon, silent, fileName}) => {
 		silent
 	});
 
-	notification.show();
-
 	notification.on('click', () => {
 		mainWindow.show();
-		sendAction('jump-to-conversation-by-img', fileName);
+		sendAction('notification-callback', {callbackName: 'onclick', id});
 	});
+
+	notification.on('close', () => {
+		sendAction('notification-callback', {callbackName: 'onclose', id});
+	});
+
+	notification.show();
 });

--- a/index.js
+++ b/index.js
@@ -307,18 +307,7 @@ function createMainWindow() {
 		webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
 		webContents.send('toggle-message-buttons', config.get('showMessageButtons'));
 
-		// Overwrite the Notification constructor in the browser process to make
-		// it call the main process via IPC. This enables custom notifications.
-		webContents.executeJavaScript(`window.Notification = Object.assign(${String(
-			class {
-				constructor(title, options) {
-					window.postMessage({
-						type: 'notification',
-						data: {title, ...options}
-					}, '*');
-				}
-			}
-		)}, window.Notification);`);
+		webContents.executeJavaScript(fs.readFileSync(path.join(__dirname, 'notifications-isolated.js'), 'utf8'));
 	});
 
 	webContents.on('new-window', (event, url, frameName, disposition, options) => {

--- a/index.js
+++ b/index.js
@@ -304,8 +304,19 @@ function createMainWindow() {
 			mainWindow.show();
 		}
 
-		mainWindow.webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
-		mainWindow.webContents.send('toggle-message-buttons', config.get('showMessageButtons'));
+		webContents.send('toggle-mute-notifications', config.get('notificationsMuted'));
+		webContents.send('toggle-message-buttons', config.get('showMessageButtons'));
+
+		// Overwrite the Notification constructor in the browser process to make
+		// it call the main process via IPC. This enables custom notifications.
+		webContents.executeJavaScript(`window.Notification = Object.assign(${String(function (title, options) {
+			window.postMessage({
+				type: 'notification',
+				data: {title, ...options}
+			}, '*');
+
+			return false;
+		})}, window.Notification);`);
 	});
 
 	webContents.on('new-window', (event, url, frameName, disposition, options) => {

--- a/index.js
+++ b/index.js
@@ -309,14 +309,16 @@ function createMainWindow() {
 
 		// Overwrite the Notification constructor in the browser process to make
 		// it call the main process via IPC. This enables custom notifications.
-		webContents.executeJavaScript(`window.Notification = Object.assign(${String(function (title, options) {
-			window.postMessage({
-				type: 'notification',
-				data: {title, ...options}
-			}, '*');
-
-			return false;
-		})}, window.Notification);`);
+		webContents.executeJavaScript(`window.Notification = Object.assign(${String(
+			class {
+				constructor(title, options) {
+					window.postMessage({
+						type: 'notification',
+						data: {title, ...options}
+					}, '*');
+				}
+			}
+		)}, window.Notification);`);
 	});
 
 	webContents.on('new-window', (event, url, frameName, disposition, options) => {

--- a/notifications-isolated.js
+++ b/notifications-isolated.js
@@ -1,0 +1,10 @@
+// Overwrite the Notification constructor in the browser process to make
+// it call the main process via IPC. This enables custom notifications.
+window.Notification = Object.assign(class {
+	constructor(title, options) {
+		window.postMessage({
+			type: 'notification',
+			data: {title, ...options}
+		}, '*');
+	}
+}, window.Notification);

--- a/notifications-isolated.js
+++ b/notifications-isolated.js
@@ -1,10 +1,30 @@
-// Overwrite the Notification constructor in the browser process to make
-// it call the main process via IPC. This enables custom notifications.
-window.Notification = Object.assign(class {
-	constructor(title, options) {
-		window.postMessage({
-			type: 'notification',
-			data: {title, ...options}
-		}, '*');
-	}
-}, window.Notification);
+(function (window) {
+	const notifications = new Map();
+
+	// Handle events sent from the browser process
+	window.addEventListener('message', ({data: {type, data}}) => {
+		if (type === 'notification-callback') {
+			const {callbackName, id} = data;
+			const notification = notifications.get(id);
+
+			if (notification && notification[callbackName]) {
+				notification[callbackName]();
+			}
+
+			if (callbackName === 'onclose') {
+				notifications.delete(id);
+			}
+		}
+	});
+
+	let counter = 1;
+
+	window.Notification = Object.assign(class {
+		constructor(title, options) {
+			this.id = counter++;
+			notifications.set(this.id, this);
+
+			window.postMessage({type: 'notification', data: {title, id: this.id, ...options}}, '*');
+		}
+	}, window.Notification);
+})(window);

--- a/notifications-isolated.js
+++ b/notifications-isolated.js
@@ -26,5 +26,8 @@
 
 			window.postMessage({type: 'notification', data: {title, id: this.id, ...options}}, '*');
 		}
+
+		// No-op, but Messenger expects this method to be present
+		close() {}
 	}, window.Notification);
 })(window);


### PR DESCRIPTION
Electron’s context isolation is preventing any `window.Notification` modification done by the preload script (`browser.js`).

This change works around that limitation by first injecting custom `window.Notification` in the main process using `webContents.executeJavaScript` and then by passing messages between browser context (Messenger code) and the Isolated Context (Caprine’s `browser.js`) via `window.postMessage/window.addEventListener('message', …)`.

As a bonus, this PR adds support for `onclick` and `onclose` Notification events used by Messenger. That allows us to remove `selectConversationByImg`, since Messenger selects the conversation in the `onclick` callback! 😃 

Fixes #700