### PR TITLE
Fix Touch Bar when on the "New Message" view

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -338,7 +338,7 @@ async function sendConversationList() {
 
 				// This is only for group chats
 				if (groupPic) {
-					// Slice image soruce from background-image style property of div
+					// Slice image source from background-image style property of div
 					groupPic.src = groupPic.style.backgroundImage.slice(5, groupPic.style.backgroundImage.length - 2);
 				}
 

--- a/browser.js
+++ b/browser.js
@@ -327,10 +327,8 @@ function closePreferences() {
 	doneButton.click();
 }
 async function sendConversationList() {
-	const sidebar = document.querySelector('[role=navigation]');
-
 	const conversations = await Promise.all(
-		[...sidebar.querySelectorAll('._1ht1')]
+		[...document.querySelector(listSelector).children]
 			.splice(0, 10)
 			.map(async el => {
 				const profilePic = el.querySelector('._55lt img');


### PR DESCRIPTION
Currently, composing a new message breaks causes Caprine to throw an error, since it tries to get a conversation image when there's none. Just skipping the image part doesn't cut it - "New Message" shows up on the Touch Bar, but tapping it doesn't do anything and tapping any conversation selects a different one (off by one).

For now, this PR only avoids the error by not trying include the "New Message" in the Touch Bar.

Eventually it would be nice to have it there, together with the ability press cmd+1 to select it, but that requires quite a lot of changes to conversation selection code.