### PR TITLE
Various styling fixes

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -50,6 +50,11 @@ body {
 	-webkit-user-drag: none;
 }
 
+/* Vertically align `Conversation Info` buttons */
+._fl2 ._30yy {
+	vertical-align: middle;
+}
+
 /* Window wrapper */
 ._4sp8 {
 	min-width: 0 !important;

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -214,6 +214,18 @@ html.dark-mode ._jf4 ._jf3 {
 	color: var(--base-fourty) !important;
 }
 
+/* Messages list: start conversation with a chat bot */
+html.dark-mode ._2xh0 ._3zc8 {
+	background-color: transparent;
+	color: var(--base-fourty);
+}
+
+/* Messages list: start conversation with a chat bot buttons */
+html.dark-mode ._2xh0 ._2xh4 {
+	background-color: transparent;
+	border-color: var(--base-ten);
+}
+
 /* Contact list: header above */
 html.dark-mode ._36ic {
 	background: var(--list-header-color) !important;

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -171,6 +171,11 @@ html.dark-mode ._1n-e {
 	color: var(--base-fourty);
 }
 
+/* Messages list: typical response time */
+html.dark-mode ._7blb {
+	color: var(--base-seventy);
+}
+
 /* Messages list: event box (event name) */
 html.dark-mode ._618l {
 	color: var(--base-seventy);

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -598,9 +598,14 @@ html.dark-mode ._3z53 {
 	color: var(--base-seventy);
 }
 
-/* Delete popover */
+/* Message popover */
 html.dark-mode ._hw2 ._53ij {
 	background-color: var(--base-seventy) !important;
+}
+
+/* Message popover text */
+html.dark-mode ._hw2 ._53ij ._hw5 {
+	color: var(--base);
 }
 
 /* Login tile and names */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -421,12 +421,12 @@ html.dark-mode ._2y8_ {
 
 /* New conversation contact list: popup hr */
 html.dark-mode ._5l38 {
-	border-top: 1px solid var(--base-ten);
+	border-top: 1px solid var(--base-ten) !important;
 }
 
 /* New conversation contact list: popup hover */
 html.dark-mode ._1k1p ._5l38 {
-	border-top: none;
+	border-top-color: transparent;
 }
 html.dark-mode ._5l37:active,
 html.dark-mode ._1k1p {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -589,8 +589,16 @@ html.dark-mode ._eb3::before {
 
 /* Sticker dialog: header borders */
 html.dark-mode ._5r8e,
-html.dark-mode ._5r86 {
+html.dark-mode ._5r86,
+html.dark-mode ._37wu,
+html.dark-mode ._37wv {
 	border-color: var(--base-five);
+}
+
+/* Sticker dialog: search input */
+html.dark-mode ._2pgc {
+	background: var(--base-ten);
+	border-color: var(--base-ten);
 }
 
 /* Record dialog: time */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -629,8 +629,8 @@ html.dark-mode ._55r1._5f0v._43di {
 }
 
 /* Login button */
-html.dark-mode button:not(._5upp) {
-	background: var(--container-color) !important;
+html.dark-mode ._5hy2 ._43dh {
+	background-color: transparent !important;
 }
 
 /* Fix the Sticker and Gaming buttons */
@@ -762,11 +762,6 @@ html.os-darwin.dark-mode ._5742 {
 
 /* Contact list: header above */
 html.os-darwin.dark-mode ._36ic {
-	background: transparent !important;
-}
-
-/* Login button */
-html.os-darwin.dark-mode button {
 	background: transparent !important;
 }
 

--- a/vibrancy.css
+++ b/vibrancy.css
@@ -9,6 +9,16 @@ html.vibrancy ._kmc ._1p1t {
 	-webkit-text-fill-color: #999 !important;
 }
 
+/* Messages list: start conversation with a chat bot */
+html.vibrancy ._2xh0 ._3zc8 {
+	background-color: transparent;
+}
+
+/* Messages list: start conversation with a chat bot buttons */
+html.vibrancy ._2xh0 ._2xh4 {
+	background-color: transparent;
+}
+
 /* Contact list: search input */
 html.vibrancy ._5iwm ._58al {
 	background-color: rgba(246, 247, 249, 0.5) !important;


### PR DESCRIPTION
**“Chat bot conversation start” element styling (a694838)**
**“Typical response type” styling in dark mode (3bdf8a7)**
**Vertically align “conversation info” buttons (11f1fba)**

before/after
<img alt="chat bot before" width="330" src="https://user-images.githubusercontent.com/66961/51088911-f5885880-1765-11e9-96d5-7efa1f61166e.png"> <img alt="chat bot after" width="330" src="https://user-images.githubusercontent.com/66961/51088912-f620ef00-1765-11e9-8b40-e24f61dd7f84.png">

**Prevent content shift on hover in “new conversation list” in dark mode (330ebbf)**

before/after
<img alt="content shift before" width="330" src="https://user-images.githubusercontent.com/66961/51089051-20bf7780-1767-11e9-8785-e4660f26279a.gif"> <img alt="content shift after" width="330" src="https://user-images.githubusercontent.com/66961/51089036-fc639b00-1766-11e9-84f6-b0530f859a76.gif">

**Improve text contrast on message popovers (4153104)**

before/after
<img alt="popover before" width="330" src="https://user-images.githubusercontent.com/66961/51088923-020cb100-1766-11e9-96e4-e6916d378b95.png"> <img alt="popover after" width="330" src="https://user-images.githubusercontent.com/66961/51088924-02a54780-1766-11e9-8ecf-d1e72d518781.png">

**Improve sticker search input styling in dark mode (74123fb)**
**Button styling throughout the app (d7fcff6)**

before/after
<img alt="sticker search before" width="330" src="https://user-images.githubusercontent.com/66961/51089064-4ba9cb80-1767-11e9-8075-c5c612769a2a.png"> <img alt="sticker search after" width="330" src="https://user-images.githubusercontent.com/66961/51088932-09cc5580-1766-11e9-8a69-a21528d430c0.png">

before/after
<img alt="buttons before" width="330" src="https://user-images.githubusercontent.com/66961/51088939-1fda1600-1766-11e9-9e6a-aba823ccb15e.png"> <img alt="buttons after" width="330" src="https://user-images.githubusercontent.com/66961/51088940-1fda1600-1766-11e9-971b-8df1a9f10b5f.png">
