### PR TITLE
Fix dark mode being disabled on non-macOS systems

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,9 @@
 'use strict';
 const Store = require('electron-store');
-const {is} = require('electron-util');
 
 const defaults = {
 	defaults: {
-		followSystemAppearance: is.macos,
+		followSystemAppearance: true,
 		darkMode: false,
 
 		// TODO: Change the default to 'sidebar' when the vibrancy issue in Electron is fixed.

--- a/config.js
+++ b/config.js
@@ -1,9 +1,10 @@
 'use strict';
 const Store = require('electron-store');
+const {is} = require('electron-util');
 
 const defaults = {
 	defaults: {
-		followSystemAppearance: true,
+		followSystemAppearance: is.macos,
 		darkMode: false,
 
 		// TODO: Change the default to 'sidebar' when the vibrancy issue in Electron is fixed.

--- a/menu.js
+++ b/menu.js
@@ -283,7 +283,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			id: 'darkMode',
 			type: 'checkbox',
 			checked: config.get('darkMode'),
-			enabled: !config.get('followSystemAppearance'),
+			enabled: !is.macos || !config.get('followSystemAppearance'),
 			accelerator: 'CommandOrControl+D',
 			click() {
 				config.set('darkMode', !config.get('darkMode'));


### PR DESCRIPTION
Dark mode option is disabled on non macOS systems since `followSystemAppearance` config value is always true by default when it should be true by default only on macOS.

Closes: https://github.com/sindresorhus/caprine/issues/733