### PR TITLE
Allow to change chat colors with HEX value

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -1,0 +1,87 @@
+'use strict';
+const {dialog} = require('electron');
+const config = require('./config');
+const {getWindow} = require('./util');
+
+module.exports = {
+	changeColor: (color) => {
+		if (!checkRgb(color)) {
+			return dialog.showMessageBox({
+				detail: 'Invalid HEX code!',
+				buttons: [
+					'Close',
+				],
+				defaultId: 0,
+			});
+		}
+
+		let name = getName(getWindow().getURL());
+		config.set('colors.' + name, color);
+		console.log('Selected color #' + color + ' for ' + name);
+	},
+
+	removeColor: () => {
+		let name = getName(getWindow().getURL());
+		config.delete('colors.' + name);
+		console.log('Removed color for ' + name);
+	},
+
+	loadColors: (webContents, url) => {
+		let name = getName(url);
+		let color = config.get('colors.' + name);
+
+		if (color === undefined) { // Colors is not set, need to manual insert messenger selected color.
+			webContents.executeJavaScript('document.querySelectorAll(\'._30yy > div > svg\').item(0).getAttribute(\'style\')', (r) => { // Get original color from HTML tag, that is override only in CSS
+				const rgb = r.split('(')[1].split(')')[0].split(', '); // Parse rgb(x, x, x) to array with values
+				insertColors(webContents, rgbToHex(rgb[0], rgb[1], rgb[2]));
+			});
+			return;
+		}
+
+		insertColors(webContents, color); // Insert selected colors from config
+	}
+};
+
+function insertColors(webContents, color) {
+	webContents.insertCSS('._3058._ui9._hh7._s1-._52mr._43by._3oh- { background-color: #' + color + ' !important; }');
+	webContents.insertCSS('._1i1j > svg > g > g > path { fill: #' + color + ' !important }');
+	webContents.insertCSS('._5j_u._4rv9._30yy._39bl > svg > path { stroke: #' + color + ' !important; }');
+	webContents.insertCSS('._30yy > div > svg, ._30yy > div > svg > path { stroke: #' + color + ' !important; }');
+	webContents.insertCSS('._30yy > div > svg > g > polygon, ._30yy > div > svg > g > circle { fill: #' + color + ' !important; }');
+	webContents.insertCSS('._30yy > div > svg > g > g > path { fill: #' + color + ' !important}');
+	webContents.insertCSS('._2her._9ah { color: #' + color + ' !important }');
+	webContents.insertCSS('._6b45 > svg > * { stroke: #' + color + ' !important }');
+	webContents.insertCSS('._5odt > svg > * { fill: #' + color + ' !important }');
+	webContents.insertCSS('._17vc > svg > * { stroke: #' + color + ' !important; fill: transparent !important}');
+	webContents.insertCSS('._3szp > div > svg > path { stroke: #' + color + ' !important }');
+	webContents.insertCSS('._3wh2 > svg > g > path { stroke: #' + color + ' !important }');
+	webContents.insertCSS('._2a45._fy2 { color: #' + color + ' !important }');
+	webContents.insertCSS('._3oh-._fy2._2wjv { color: #' + color + ' !important }');
+	webContents.insertCSS('._30yy._38lh._39bl { color: #' + color + ' !important }');
+	webContents.insertCSS('._ih- { color: #' + color + ' !important }');
+	webContents.insertCSS('._4rpi > svg > path { stroke: #' + color + ' !important }');
+	webContents.insertCSS('._4rv9._30yy._39bl { stroke: #' + color + ' !important }');
+}
+
+function getName(url) {
+	return url.split('/t/')[1].replace(new RegExp('\\.', 'g'), '_');
+}
+
+function checkRgb(color) { // RGB code without '#'
+	return /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test('#' + color);
+}
+
+function rgbToHex (r,g,b) {
+	const red = colorToHex(r);
+	const green = colorToHex(g);
+	const blue = colorToHex(b);
+	return red+green+blue;
+}
+
+function colorToHex (rgb) {
+	let hex = Number(rgb).toString(16);
+	if (hex.length < 2) {
+		hex = "0" + hex;
+	}
+	return hex;
+}

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const config = require('./config');
 const tray = require('./tray');
 const {sendAction} = require('./util');
 const emoji = require('./emoji');
+const colors = require('./colors');
 
 require('./touch-bar'); // eslint-disable-line import/no-unassigned-import
 
@@ -385,6 +386,12 @@ function createMainWindow() {
 
 		event.preventDefault();
 		electron.shell.openExternal(url);
+	});
+
+	webContents.on('did-start-navigation', (event, url) => {
+		if(url.includes('/t/')) {
+			colors.loadColors(webContents, url); // Chat is opened, process colors
+		}
 	});
 })();
 

--- a/menu.js
+++ b/menu.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const fs = require('fs');
 const electron = require('electron');
+const prompt = require('electron-prompt');
 const {
 	is,
 	appMenu,
@@ -13,6 +14,7 @@ const {
 const config = require('./config');
 const {sendAction, showRestartDialog} = require('./util');
 const emoji = require('./emoji');
+const colors = require('./colors');
 
 const {app, shell} = electron;
 
@@ -425,7 +427,32 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			click() {
 				sendAction('insert-text');
 			}
+		},
+		{
+			type: 'separator'
+		},
+		{
+			label: 'Change color for Caprine users',
+			click() {
+				prompt({
+					title: 'Select color',
+					label: 'Color (HEX): #',
+					value: '123456',
+					inputAttrs: {
+						type: 'text'
+					}
+				}).then((r) => {
+					colors.changeColor(r.replace('#', ''));
+				});
+			}
+		},
+		{
+			label: 'Remove color for Caprine users',
+			click() {
+				colors.removeColor();
+			}
 		}
+
 	];
 
 	const helpSubmenu = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1713,6 +1713,14 @@
 				}
 			}
 		},
+		"doc-ready": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/doc-ready/-/doc-ready-1.0.4.tgz",
+			"integrity": "sha1-N/U5GWnP+ZQwP9/vLl1QNX+BZNM=",
+			"requires": {
+				"eventie": "^1"
+			}
+		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2008,6 +2016,14 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
+			}
+		},
+		"electron-prompt": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/electron-prompt/-/electron-prompt-1.3.0.tgz",
+			"integrity": "sha512-BsoPDQ84QEzQtqWjbbDlFqwKKAgC6F6RKbLVKSRC4AQLxOqfqKlSm56RLNk1hV00iG4IutJiALgGhKhmxysEIQ==",
+			"requires": {
+				"doc-ready": "^1.0.4"
 			}
 		},
 		"electron-publish": {
@@ -2734,6 +2750,11 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
+		},
+		"eventie": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/eventie/-/eventie-1.0.6.tgz",
+			"integrity": "sha1-1P/IsMK15JPCqhsiy+kY067nRDc="
 		},
 		"execa": {
 			"version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"electron-dl": "^1.0.0",
 		"electron-is-dev": "^1.0.0",
 		"electron-log": "^2.0.2",
+		"electron-prompt": "^1.3.0",
 		"electron-store": "^2.0.0",
 		"electron-updater": "^4.0.6",
 		"electron-util": "^0.10.2",


### PR DESCRIPTION
Allow to change chat colors with HEX value. Feature will be visible only for you (or maybe for other Caprine users in future).

TODO:
 - Sync colors with other Caprine users, like in original messenger (send "change color command" with HEX to second user)
 - Create color palette instead of manual write HEX value (currently I haven't idea how to code it)
 - Style prompt to dark theme
 - Find other color selectors (most are already found!)
 - Add warning, that you must switch to another chat and back to view new color
 - Fix 'like emoji' as chat button (sometimes does not change color, or left-margin disappear)

![g1x0m9cpcc](https://user-images.githubusercontent.com/10632503/51445539-93e86100-1d06-11e9-9c6e-03d318d4bfa3.png)
