### PR TITLE
Run tests on push instead of commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "npm test"
+			"pre-push": "npm test"
 		}
 	}
 }


### PR DESCRIPTION
There’s no need to run them after each commit, and the time needed to launch tests each time adds up. It also prevented temporarily committing unfinished code, made it difficult to rebase commits, etc.