### PR TITLE
Support persisting `keepMeSignedIn` toggled with keyboard

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -519,7 +519,7 @@ window.addEventListener('load', () => {
 	if (location.pathname.startsWith('/login')) {
 		const keepMeSignedInCheckbox = document.querySelector('#u_0_0');
 		keepMeSignedInCheckbox.checked = config.get('keepMeSignedIn');
-		keepMeSignedInCheckbox.addEventListener('click', () => {
+		keepMeSignedInCheckbox.addEventListener('change', () => {
 			config.set('keepMeSignedIn', !config.get('keepMeSignedIn'));
 		});
 	}


### PR DESCRIPTION
To persist keepMeSignedIn checkbox state, detects changes using onChange event instead of onClick event.

Handles case when checkbox is (un)checked using keyboard.

Improves #698 which fixes #640.