### PR TITLE
Fix emoji style URL (add wildcard)

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -168,8 +168,8 @@ function initRequestsFiltering(): void {
 		urls: [
 			`*://*.${domain}/*typ.php*`, // Type indicator blocker
 			`*://*.${domain}/*change_read_status.php*`, // Seen indicator blocker
-			'*://static.xx.fbcdn.net/images/emoji.php/v9/*', // Emoji
-			'*://facebook.com/images/emoji.php/v9/*' // Emoji
+			'*://*.fbcdn.net/images/emoji.php/v9/*', // Emoji
+			'*://*.facebook.com/images/emoji.php/v9/*' // Emoji
 		]
 	};
 


### PR DESCRIPTION
Today I notice that old emoji styles does not work on my second PC (on first it still works). I looks like facebook sometimes fetch emoji from other domain. I created wildcard on subdomain to fix this problem.

<img width="1021" alt="noxljgvrbw" src="https://user-images.githubusercontent.com/10632503/52043603-6ee2c200-2540-11e9-9243-2f58d1cb923d.png">