### PR TITLE
Add option to block delivery receipts

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -25,7 +25,8 @@ const defaults = {
 	flashWindowOnMessage: true,
 	block: {
 		chatSeen: false,
-		typingIndicator: false
+		typingIndicator: false,
+		deliveryReceipt: false
 	},
 	emojiStyle: 'facebook-3-0' as EmojiStyle,
 	confirmImagePaste: true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -169,6 +169,8 @@ function initRequestsFiltering(): void {
 		urls: [
 			`*://*.${domain}/*typ.php*`, // Type indicator blocker
 			`*://*.${domain}/*change_read_status.php*`, // Seen indicator blocker
+			`*://*.${domain}/*delivery_receipts*`, // Delivery receipts indicator blocker
+			`*://*.${domain}/*unread_threads*`, // Delivery receipts indicator blocker
 			'*://*.fbcdn.net/images/emoji.php/v9/*', // Emoji
 			'*://*.facebook.com/images/emoji.php/v9/*' // Emoji
 		]
@@ -181,6 +183,8 @@ function initRequestsFiltering(): void {
 			callback({cancel: config.get('block.typingIndicator')});
 		} else if (url.includes('change_read_status.php')) {
 			callback({cancel: config.get('block.chatSeen')});
+		} else if (url.includes('delivery_receipts') || url.includes('unread_threads')) {
+			callback({cancel: config.get('block.deliveryReceipt')});
 		}
 	});
 }

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -172,6 +172,14 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			type: 'checkbox',
+			label: 'Block Delivery Receipts',
+			checked: config.get('block.deliveryReceipt'),
+			click(item) {
+				config.set('block.deliveryReceipt', item.checked);
+			}
+		},
+		{
 			label: 'Hardware Acceleration',
 			type: 'checkbox',
 			checked: config.get('hardwareAcceleration'),


### PR DESCRIPTION
Closes #699 

Added as an option inside `Caprine Preferences`.

Let me know if anything needs to be changed.
I've tested this on macOS Mojave (10.14.2).