### PR TITLE
Fix poll title color in dark mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -188,6 +188,11 @@ html.dark-mode ._618k div hr {
 	border-top: 1px solid var(--base-five);
 }
 
+/* Messages list: Poll color (title) */
+html.dark-mode ._3b4u {
+	color: var(--base-seventy);
+}
+
 /* Messages list: text header above the messages */
 html.dark-mode ._17w2,
 html.dark-mode ._ih3 ._3oh-,


### PR DESCRIPTION
Just a minor css tweak to fix poll title text color in dark mode.