### PR TITLE
Remove shared video bars

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -135,26 +135,6 @@ html.hide-dropdowns .uiContextualLayerPositioner {
 	display: none;
 }
 
-/* Message box: fix video width */
-._3zvs._5z-5 {
-	width: 100% !important;
-}
-._2poz._52mr._ui9._2n8h._2n8i._5fk1 {
-	width: 100% !important;
-}
-._ccq._4tsk._3o67._52mr._4-od {
-	width: 100% !important;
-}
-._1c_u {
-	width: 100% !important;
-}
-._53j5 {
-	width: 100% !important;
-}
-._ox1._21y0 {
-	width: 100% !important;
-}
-
 /* Message box: hide bottom white line */
 .chatAttachmentShelf:empty {
 	display: none !important;


### PR DESCRIPTION
Shared videos had bars on left and rights side. Removing this old fix
stops that behavior.

Closes: https://github.com/sindresorhus/caprine/issues/805