### PR TITLE
Add `camera` plug to Snap build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,12 @@
 			"description": "Caprine is an unofficial and privacy focused Facebook Messenger app with many useful features.",
 			"category": "Network;Chat"
 		},
+		"snap": {
+			"plugs": [
+				"default",
+				"camera"
+			]
+		}
 		"win": {
 			"verifyUpdateCodeSignature": false
 		}

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 				"default",
 				"camera"
 			]
-		}
+		},
 		"win": {
 			"verifyUpdateCodeSignature": false
 		}


### PR DESCRIPTION
Camera doesn't work for me when installing from the snap store, and it looks like the reason is because it doesn't have permissions. The [old workaround of `snap install --classic`](https://github.com/sindresorhus/caprine/issues/568) no longer works as of `snapd@2.36.2` ([relevant PR](https://github.com/snapcore/snapd/pull/6039)). 

Reading the relevant docs for [electron-builder](https://www.electron.build/configuration/snap) and [snap](https://docs.snapcraft.io/interface-management/6154), it seems like the right solution is to use the default confinement model and to explicitly specify a `snap.plugs` that includes `camera` in the `electron-builder` config.