### PR TITLE
Allow navigation to alternate messenger domains

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -394,7 +394,7 @@ function createMainWindow(): BrowserWindow {
 	webContents.on('will-navigate', (event, url) => {
 		const isMessengerDotCom = (url: string): boolean => {
 			const {hostname} = new URL(url);
-			return hostname === 'www.messenger.com';
+			return hostname.endsWith('messenger.com');
 		};
 
 		const isTwoFactorAuth = (url: string): boolean => {

--- a/source/index.ts
+++ b/source/index.ts
@@ -394,7 +394,7 @@ function createMainWindow(): BrowserWindow {
 	webContents.on('will-navigate', (event, url) => {
 		const isMessengerDotCom = (url: string): boolean => {
 			const {hostname} = new URL(url);
-			return hostname.endsWith('messenger.com');
+			return hostname.endsWith('.messenger.com');
 		};
 
 		const isTwoFactorAuth = (url: string): boolean => {


### PR DESCRIPTION
I was having an issue where navigating to something like `prod.messenger.com` would open in my browser. I'd like to be able to do that in the Caprine app, so I changed the navigation rules to allow any hostname that contains `messenger.com`.