### PR TITLE
Add `License Agreement` screen on Windows installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,9 @@
 			"description": "Caprine is an unofficial and privacy focused Facebook Messenger app with many useful features.",
 			"category": "Network;Chat"
 		},
+		"nsis": {
+			"license": "license"
+		},
 		"snap": {
 			"plugs": [
 				"default",


### PR DESCRIPTION
### Description

The PR enables the `nsis` installer to display the MIT project license to the user, through a `License Agreement` screen/step, before proceeding on with the installation.
The main purpose of this one is to provide the installation process with a more Windows-native feel.

More info regarding the `license` option: https://www.electron.build/configuration/nsis

This can be considered a fairly subjective addition, thus feel free to reject it if it doesn't look appealing enough : )

### Preview

<p align="center"><img src="https://user-images.githubusercontent.com/12670537/54715095-45ffa600-4b5b-11e9-8a1d-1ecd6660bd6d.png" /></p>
