### PR TITLE
CSS tweaks

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -289,3 +289,8 @@ body ._4_j4 ._39bj {
 body.show-message-buttons ._4_j4 ._39bj {
 	display: flex;
 }
+
+/* Window background, affects vibrant views and Settings open/close transition */
+._2sdm {
+	background-color: transparent !important;
+}

--- a/css/browser.css
+++ b/css/browser.css
@@ -299,3 +299,9 @@ body.show-message-buttons ._4_j4 ._39bj {
 ._4gd0 {
 	background-color: transparent !important;
 }
+
+/* Typing indicator */
+._4a0v._1x3z {
+	display: flex;
+	justify-content: center;
+}

--- a/css/browser.css
+++ b/css/browser.css
@@ -294,3 +294,8 @@ body.show-message-buttons ._4_j4 ._39bj {
 ._2sdm {
 	background-color: transparent !important;
 }
+
+/* Background under the typing indicator */
+._4gd0 {
+	background-color: transparent !important;
+}

--- a/css/code-blocks.css
+++ b/css/code-blocks.css
@@ -2,7 +2,7 @@
 ._wu0 {
 	--code-block-base: #1d1f21;
 	--code-block-background: transparent;
-	--code-block-border: rgba(0, 0, 0, .1);
+	--code-block-border: rgba(0, 0, 0, 0.1);
 	--code-block-primary: #de935f;
 	--code-block-meta: #969896;
 	--code-block-tag: #a3685a;
@@ -111,9 +111,9 @@
 
 /* Tomorrow dark theme for code blocks */
 html.dark-mode ._wu0 {
-	color: var(--base);
 	--code-block-base: #c5c8c6;
 	--code-block-border: var(--base-ten);
+	color: var(--base);
 }
 
 /* Full-window vibrancy */

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -780,7 +780,7 @@ html.dark-mode ._2r2v {
 }
 
 /* "Missed call" dialog buttons separator */
-html.dark-mode ._4eb_ ._30vt:not(:last-child):after {
+html.dark-mode ._4eb_ ._30vt:not(:last-child)::after {
 	border-left-color: var(--base-ten);
 }
 

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -790,9 +790,9 @@ html.dark-mode ._2n1t {
 }
 
 /* Quoted text in inline replies */
-html.dark-mode ._1nc7 ._pye,
-html.dark-mode ._1nc6 ._pye,
-html.dark-mode ._hh7 ._pye {
+html.dark-mode ._1nc7:not(._43by) ._pye,
+html.dark-mode ._1nc6:not(._43by) ._pye,
+html.dark-mode ._hh7:not(._43by) ._pye {
 	color: var(--base-fifty) !important;
 }
 

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -795,3 +795,8 @@ html.dark-mode ._1nc6 ._pye,
 html.dark-mode ._hh7 ._pye {
 	color: var(--base-fifty) !important;
 }
+
+/* Music widget title */
+html.dark-mode ._44ju ._44jz {
+	color: #fff;
+}

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -800,3 +800,15 @@ html.dark-mode ._hh7 ._pye {
 html.dark-mode ._44ju ._44jz {
 	color: #fff;
 }
+
+/* Close icon in the "New Messenger version is available" banner */
+html.dark-mode ._2cij ._2cik {
+	filter: invert(0.66);
+	left: unset;
+	right: 12px;
+}
+
+/* "New Messenger version is available" banner icon */
+html.dark-mode ._2cij ._2cil {
+	filter: invert(0.66);
+}

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -801,6 +801,16 @@ html.dark-mode ._67tw {
 	color: var(--base-fifty);
 }
 
+/* Reply tag */
+html.dark-mode ._4k7a {
+	color: var(--base-fifty);
+}
+
+/* Reply tag icon */
+html.dark-mode ._6e38 {
+	filter: invert(0.66);
+}
+
 /* Music widget title */
 html.dark-mode ._44ju ._44jz {
 	color: #fff;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -691,7 +691,7 @@ html.dark-mode ._29ey {
 }
 html.dark-mode .fbNubFlyoutAttachments,
 html.dark-mode .chatAttachmentShelf {
-	background: var(--container-color) !important;
+	background: var(--container-color);
 	color: var(--base-seventy);
 }
 html.dark-mode .chatAttachmentShelf {

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -774,9 +774,14 @@ html.dark-mode ._koh li:not(.selected) {
 	color: var(--base-seventy);
 }
 
-/* "Missed call" timestamp */
+/* "Missed call" dialog timestamp */
 html.dark-mode ._2r2v {
 	color: var(--base-fourty) !important;
+}
+
+/* "Missed call" dialog buttons separator */
+html.dark-mode ._4eb_ ._30vt:not(:last-child):after {
+	border-left-color: var(--base-ten);
 }
 
 /* "Incoming call" subheading */

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -796,6 +796,11 @@ html.dark-mode ._hh7:not(._43by) ._pye {
 	color: var(--base-fifty) !important;
 }
 
+/* Quoted text in the message composer */
+html.dark-mode ._67tw {
+	color: var(--base-fifty);
+}
+
 /* Music widget title */
 html.dark-mode ._44ju ._44jz {
 	color: #fff;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -49,7 +49,7 @@ html.dark-mode ._o46:not(._nd_) ._hh7 a {
 }
 
 /* Message list: link in message bubble */
-html.dark-mode ._hh7 a:hover {
+html.dark-mode ._hh7 a:not(._2t5t):hover {
 	background: transparent !important;
 }
 

--- a/css/vibrancy.css
+++ b/css/vibrancy.css
@@ -204,4 +204,16 @@ html.full-vibrancy ._6e38 {
 	filter: brightness(0.66);
 }
 
+/* Message composer: link preview */
+html.full-vibrancy .chatAttachmentShelf,
+html.full-vibrancy .fbNubFlyoutAttachments,
+html.full-vibrancy.dark-mode .chatAttachmentShelf,
+html.full-vibrancy.dark-mode .fbNubFlyoutAttachments {
+	background: transparent !important;
+}
+html.full-vibrancy .chatAttachmentShelf,
+html.full-vibrancy.dark-mode .chatAttachmentShelf {
+	border-top-color: rgba(0, 0, 0, 0.1);
+}
+
 /* -- BLOCK END: full-window vibrancy -- */

--- a/css/vibrancy.css
+++ b/css/vibrancy.css
@@ -199,4 +199,9 @@ html.full-vibrancy.dark-mode ._2zl5 {
 	background-color: var(--container-color);
 }
 
+/* Reply tag icon */
+html.full-vibrancy ._6e38 {
+	filter: brightness(0.66);
+}
+
 /* -- BLOCK END: full-window vibrancy -- */

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"scripts": {
 		"postinstall": "electron-builder install-app-deps",
-		"lint": "tsc && xo && stylelint '*.css'",
+		"lint": "tsc && xo && stylelint 'css/*.css'",
 		"test": "npm run lint",
 		"start": "tsc && electron .",
 		"pack": "tsc && electron-builder --dir",


### PR DESCRIPTION
# CSS tweaks

#### Fix the stylelint invocation 620c827

Stylelint wasn't run on `npm test` (regression introduced with TS migration). My bad.

#### Improve the music widget title color in dark mode cdd1cfd

<img width="300" alt="music-widget-before" src="https://user-images.githubusercontent.com/66961/55325348-1159eb80-5485-11e9-867c-01f2020e4cb8.png"> <img width="300" alt="music-widget-after" src="https://user-images.githubusercontent.com/66961/55325347-10c15500-5485-11e9-9f0e-2b543264d589.png">

#### Tweak the “new Messenger version” banner in dark mode (fixes #835) d6f35fd

<img width="600" alt="new-version-before" src="https://user-images.githubusercontent.com/66961/55324141-7ad7fb00-5481-11e9-9a8b-e857874e8735.png"> <img width="600" alt="new-version-after" src="https://user-images.githubusercontent.com/66961/55324142-7ad7fb00-5481-11e9-8968-298f09bb3d1e.png">

#### Tweak the inline replies in dark mode 4e0d6e8
#### Tweak reply tags 111a384

<img width="300" alt="reply-before-light" src="https://user-images.githubusercontent.com/66961/55325080-4d408100-5484-11e9-9a49-4614d7222659.png"> <img width="300" alt="reply-after-light" src="https://user-images.githubusercontent.com/66961/55325077-4d408100-5484-11e9-9c9b-6df57d2fecf9.png">

<img width="300" alt="reply-before-dark" src="https://user-images.githubusercontent.com/66961/55325079-4d408100-5484-11e9-8217-0910eb61dbf0.png"> <img width="300" alt="reply-after-dark" src="https://user-images.githubusercontent.com/66961/55325076-4ca7ea80-5484-11e9-881a-11b1676f4944.png">

#### Tweak quoted text in the composer in dark mode 4499dad

<img width="300" alt="quoted-before" src="https://user-images.githubusercontent.com/66961/55324775-5e3cc280-5483-11e9-947d-c0755bf37240.png"> <img width="300" alt="quoted-after" src="https://user-images.githubusercontent.com/66961/55324774-5da42c00-5483-11e9-83f7-1eb23307a2c0.png">

#### Fix the white background under the typing indicator (fixes #669) 2f6c616
#### Fix Messenger’s squished typing indicator bug 0b6e250

<img width="600" alt="typing-before" src="https://user-images.githubusercontent.com/66961/55323962-f2595a80-5480-11e9-80c8-dd455c7ced80.png"> <img width="600" alt="typing-after" src="https://user-images.githubusercontent.com/66961/55323961-f2595a80-5480-11e9-93a5-5cf5ef2fb9df.png">

#### Tweak the link preview in the message composer in full vibrancy mode (fixes #670) 66e865c

<img width="600" alt="composer-link-before-light" src="https://user-images.githubusercontent.com/66961/55324581-d5be2200-5482-11e9-8ce7-edf92851d7ed.png"> <img width="600" alt="composer-link-after-light" src="https://user-images.githubusercontent.com/66961/55324583-d5be2200-5482-11e9-93a4-cf5012d51dfc.png">

<img width="600" alt="composer-link-before-dark" src="https://user-images.githubusercontent.com/66961/55324582-d5be2200-5482-11e9-9ff8-eb5cf2b91cf3.png"> <img width="600" alt="composer-link-after-dark" src="https://user-images.githubusercontent.com/66961/55324584-d656b880-5482-11e9-8065-eae0b7f93f88.png">
