### PR TITLE
Support the workplace.com domain

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -407,7 +407,8 @@ function createMainWindow(): BrowserWindow {
 		const isWorkChat = (url: string): boolean => {
 			const {hostname, pathname} = new URL(url);
 
-			if (hostname === 'work.facebook.com') {
+			// Facebook is now redirecting to the workplace domain while tenants are transitioning to the new domain
+			if ((hostname === 'work.facebook.com') || (hostname === 'work.workplace.com')) {
 				return true;
 			}
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -413,7 +413,8 @@ function createMainWindow(): BrowserWindow {
 
 			if (
 				// Example: https://company-name.facebook.com/login
-				hostname.endsWith('.facebook.com') &&
+				// Example: https://company-name.workplace.com/login
+				(hostname.endsWith('.facebook.com') || hostname.endsWith('.workplace.com')) &&
 				(pathname.startsWith('/login') || pathname.startsWith('/chat'))
 			) {
 				return true;

--- a/source/index.ts
+++ b/source/index.ts
@@ -407,14 +407,23 @@ function createMainWindow(): BrowserWindow {
 		const isWorkChat = (url: string): boolean => {
 			const {hostname, pathname} = new URL(url);
 
+<<<<<<< HEAD
+			if (hostname === 'work.facebook.com' || hostname === 'work.workplace.com') {
+=======
 			// Facebook is now redirecting to the workplace domain while tenants are transitioning to the new domain
 			if (hostname === 'work.facebook.com') || hostname === 'work.workplace.com') {
+>>>>>>> 1ee1f16ddbdf58272be43509bff0d5ca8e6b1533
 				return true;
 			}
 
 			if (
+<<<<<<< HEAD
+				// Example: https://company-name.facebook.com/login or
+				//   		https://company-name.workplace.com/login
+=======
 				// Example: https://company-name.facebook.com/login
 				// Example: https://company-name.workplace.com/login
+>>>>>>> 1ee1f16ddbdf58272be43509bff0d5ca8e6b1533
 				(hostname.endsWith('.facebook.com') || hostname.endsWith('.workplace.com')) &&
 				(pathname.startsWith('/login') || pathname.startsWith('/chat'))
 			) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -407,23 +407,13 @@ function createMainWindow(): BrowserWindow {
 		const isWorkChat = (url: string): boolean => {
 			const {hostname, pathname} = new URL(url);
 
-<<<<<<< HEAD
 			if (hostname === 'work.facebook.com' || hostname === 'work.workplace.com') {
-=======
-			// Facebook is now redirecting to the workplace domain while tenants are transitioning to the new domain
-			if (hostname === 'work.facebook.com') || hostname === 'work.workplace.com') {
->>>>>>> 1ee1f16ddbdf58272be43509bff0d5ca8e6b1533
 				return true;
 			}
 
 			if (
-<<<<<<< HEAD
 				// Example: https://company-name.facebook.com/login or
 				//   		https://company-name.workplace.com/login
-=======
-				// Example: https://company-name.facebook.com/login
-				// Example: https://company-name.workplace.com/login
->>>>>>> 1ee1f16ddbdf58272be43509bff0d5ca8e6b1533
 				(hostname.endsWith('.facebook.com') || hostname.endsWith('.workplace.com')) &&
 				(pathname.startsWith('/login') || pathname.startsWith('/chat'))
 			) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -408,7 +408,7 @@ function createMainWindow(): BrowserWindow {
 			const {hostname, pathname} = new URL(url);
 
 			// Facebook is now redirecting to the workplace domain while tenants are transitioning to the new domain
-			if ((hostname === 'work.facebook.com') || (hostname === 'work.workplace.com')) {
+			if (hostname === 'work.facebook.com') || hostname === 'work.workplace.com') {
 				return true;
 			}
 


### PR DESCRIPTION
This seems to fix #845 for me.
Built and tested on Linux.

Redirects are as follows:
* work.facebook.com (initial page loaded by caprine)
* work.workplace.com 
* companyname.workplace.com

More info on the domain switch: 
* https://www.facebook.com/help/work/1116975388401705?helpref=hc_fnav
* https://www.facebook.com/workplace/resources/deepen/prepare-community-workplace-domain