### PR TITLE
Fix dark mode style for nickname dialog placeholder

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -361,8 +361,7 @@ html.dark-mode ._1li- {
 }
 
 /* Right sidebar: group chat names */
-html.dark-mode ._2jnv,
-html.dark-mode ._5rpu {
+html.dark-mode ._2jnu ._2jnv {
 	color: var(--base-seventy);
 }
 
@@ -826,4 +825,9 @@ html.dark-mode ._2cij ._2cik {
 /* "New Messenger version is available" banner icon */
 html.dark-mode ._2cij ._2cil {
 	filter: invert(0.66);
+}
+
+/* "Edit Nickname" dialog input placeholder */
+html.dark-mode ._1p1u ._1p1v {
+	color: var(--base-thirty);
 }


### PR DESCRIPTION
Makes dark mode placeholder text in the nickname dialog match placeholder text elsewhere (e.g. "Add People" dialog).

![caprine-nickname-dialog-placeholder](https://user-images.githubusercontent.com/117983/56376574-d3bbc900-61cd-11e9-807e-cd2c1b33769a.gif)

Closes #857 