### PR TITLE
Add contact list styling for inactive window

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -270,11 +270,11 @@ a,
 }
 
 /* Contact list: person (selected) window inactive */
-._1ht1._1ht2.inactive {
+html.inactive ._1ht1._1ht2 {
 	background: var(--selected-conversation-background-inactive) !important;
 	color: var(--black) !important;
 }
-._1ht1._1ht2.inactive * {
+html.inactive ._1ht1._1ht2 * {
 	color: rgba(0, 0, 0, 0.8);
 }
 

--- a/css/browser.css
+++ b/css/browser.css
@@ -1,5 +1,7 @@
 :root {
 	--selected-conversation-background: linear-gradient(hsla(209, 110%, 45%, 0.9), hsla(209, 110%, 42%, 0.9));
+	--selected-conversation-background-inactive: #d2d2d2;
+	--black: #000;
 }
 
 html {
@@ -269,8 +271,8 @@ a,
 
 /* Contact list: person (selected) window inactive */
 ._1ht1._1ht2.inactive {
-	background: #D2D2D2 !important;
-	color: #000000 !important;
+	background: var(--selected-conversation-background-inactive) !important;
+	color: var(--black) !important;
 }
 ._1ht1._1ht2.inactive * {
 	color: rgba(0, 0, 0, 0.8);

--- a/css/browser.css
+++ b/css/browser.css
@@ -267,6 +267,15 @@ a,
 	color: rgba(255, 255, 255, 0.8);
 }
 
+/* Contact list: person (selected) window inactive */
+._1ht1._1ht2.inactive {
+	background: #D2D2D2 !important;
+	color: #000000 !important;
+}
+._1ht1._1ht2.inactive * {
+	color: rgba(0, 0, 0, 0.8);
+}
+
 /* Remove top Facebook cookie banner */
 .fbPageBanner {
 	display: none !important;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -266,6 +266,14 @@ html.dark-mode ._1ht6 {
 	color: var(--base-seventy);
 }
 
+/* Contact list: person (selected) window inactive */
+html.dark-mode ._1ht1._1ht2.inactive {
+	background: var(--base-twenty) !important;
+}
+html.dark-mode ._1ht1._1ht2.inactive * {
+	color: var(--base-seventy);
+}
+
 /* Contact list: message blurb */
 html.dark-mode ._1htf,
 /* Contact list: (for format) person: message blurb */

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -267,10 +267,10 @@ html.dark-mode ._1ht6 {
 }
 
 /* Contact list: person (selected) window inactive */
-html.dark-mode ._1ht1._1ht2.inactive {
+html.dark-mode.inactive ._1ht1._1ht2 {
 	background: var(--base-twenty) !important;
 }
-html.dark-mode ._1ht1._1ht2.inactive * {
+html.dark-mode.inactive ._1ht1._1ht2 * {
 	color: var(--base-seventy);
 }
 

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -573,13 +573,13 @@ window.addEventListener('load', () => {
 // Toggles the sidebar color to gray when window is inactive
 window.addEventListener('blur', () => {
 	const selected = document.querySelector('._1ht1._1ht2');
-	if(selected !== null) {
+	if (selected !== null) {
 		selected.classList.add('inactive');
 	}
 });
 window.addEventListener('focus', () => {
 	const selected = document.querySelector('._1ht1._1ht2');
-	if(selected !== null) {
+	if (selected !== null) {
 		selected.classList.remove('inactive');
 	}
 });

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -570,6 +570,16 @@ window.addEventListener('load', () => {
 	}
 });
 
+// Toggles the sidebar color to gray when window is inactive
+window.addEventListener('blur', () => {
+    const selected = document.querySelector('._1ht1._1ht2');
+    selected.classList.add('inactive');
+});
+window.addEventListener('focus', () => {
+    const selected = document.querySelector('._1ht1._1ht2');
+    selected.classList.remove('inactive');
+});
+
 // It's not possible to add multiple accelerators
 // so this needs to be done the old-school way
 document.addEventListener('keydown', async event => {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -572,16 +572,16 @@ window.addEventListener('load', () => {
 
 // Toggles the sidebar color to gray when window is inactive
 window.addEventListener('blur', () => {
-    const selected = document.querySelector('._1ht1._1ht2');
-    if(selected !== null) {
-    	selected.classList.add('inactive');
-    }
+	const selected = document.querySelector('._1ht1._1ht2');
+	if(selected !== null) {
+		selected.classList.add('inactive');
+	}
 });
 window.addEventListener('focus', () => {
-    const selected = document.querySelector('._1ht1._1ht2');
-    if(selected !== null) {
-    	selected.classList.remove('inactive');
-    }
+	const selected = document.querySelector('._1ht1._1ht2');
+	if(selected !== null) {
+		selected.classList.remove('inactive');
+	}
 });
 
 // It's not possible to add multiple accelerators

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -573,11 +573,15 @@ window.addEventListener('load', () => {
 // Toggles the sidebar color to gray when window is inactive
 window.addEventListener('blur', () => {
     const selected = document.querySelector('._1ht1._1ht2');
-    selected.classList.add('inactive');
+    if(selected !== null) {
+    	selected.classList.add('inactive');
+    }
 });
 window.addEventListener('focus', () => {
     const selected = document.querySelector('._1ht1._1ht2');
-    selected.classList.remove('inactive');
+    if(selected !== null) {
+    	selected.classList.remove('inactive');
+    }
 });
 
 // It's not possible to add multiple accelerators

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -572,13 +572,13 @@ window.addEventListener('load', () => {
 
 // Toggles the sidebar color to gray when window is inactive
 window.addEventListener('blur', () => {
-	const selected = document.querySelector('._1ht1._1ht2');
+	const selected = document.documentElement;
 	if (selected !== null) {
 		selected.classList.add('inactive');
 	}
 });
 window.addEventListener('focus', () => {
-	const selected = document.querySelector('._1ht1._1ht2');
+	const selected = document.documentElement;
 	if (selected !== null) {
 		selected.classList.remove('inactive');
 	}


### PR DESCRIPTION
Fixes #702, when the window is inactive / blurred, the open chat changes to gray in the contact list. When the window is refocused, the open chat returns to blue in the contact list.

The selected state when the window is active (also the original "inactive" window state):
![image](https://user-images.githubusercontent.com/32414721/56527931-6d5fdf00-651c-11e9-8089-6c58c05fc37a.png)
 
Inactive window for light mode:
![light mode inactive](https://user-images.githubusercontent.com/32414721/56473046-f51dee80-6433-11e9-987c-0aa4c998cd25.png)

On dark mode:
![dark mode inactive](https://user-images.githubusercontent.com/32414721/56473052-fb13cf80-6433-11e9-8882-44ad46c95700.png)