### PR TITLE
Prepare for Mac App Store submission

### DIFF
--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -6,8 +6,6 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"endOfLine": "lf"
 	},
 	"build": {
+		"afterSign": "./replace-mas-icon.js",
 		"files": [
 			"**/*",
 			"!media/**/*",

--- a/package.json
+++ b/package.json
@@ -91,11 +91,20 @@
 	"build": {
 		"files": [
 			"**/*",
-			"!media${/*}"
+			"!media/**/*",
+			"!source/**/*"
 		],
 		"appId": "com.sindresorhus.caprine",
 		"mac": {
+			"target": [
+				"dmg",
+				"mas",
+				"zip"
+			],
 			"category": "public.app-category.social-networking",
+			"electronLanguages": [
+				"en"
+			],
 			"electronUpdaterCompatibility": ">=2.15.0",
 			"darkModeSupport": true
 		},

--- a/replace-mas-icon.js
+++ b/replace-mas-icon.js
@@ -1,16 +1,18 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+'use strict';
 const fs = require('fs');
 const path = require('path');
 const pkg = require('./package.json');
 
 const APP_NAME = pkg.productName;
-const ICNS_PATH = path.join(__dirname, 'media', 'IconMas.icns');
+const ICON_PATH = path.join(__dirname, 'build', 'IconMas.icns');
 
 exports.default = context => {
 	const target = context.targets[0].name;
+
 	if (target === 'mas') {
 		const {appOutDir} = context;
+
 		const appIconPath = path.join(
 			appOutDir,
 			`${APP_NAME}.app`,
@@ -18,6 +20,7 @@ exports.default = context => {
 			'Resources',
 			`${APP_NAME}.icns`
 		);
-		fs.copyFileSync(ICNS_PATH, appIconPath);
+
+		fs.copyFileSync(ICON_PATH, appIconPath);
 	}
 };

--- a/replace-mas-icon.js
+++ b/replace-mas-icon.js
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+const path = require('path');
+const pkg = require('./package.json');
+
+const APP_NAME = pkg.productName;
+const ICNS_PATH = path.join(__dirname, 'media', 'IconMas.icns');
+
+exports.default = context => {
+	const target = context.targets[0].name;
+	if (target === 'mas') {
+		const {appOutDir} = context;
+		const appIconPath = path.join(
+			appOutDir,
+			`${APP_NAME}.app`,
+			'Contents',
+			'Resources',
+			`${APP_NAME}.icns`
+		);
+		fs.copyFileSync(ICNS_PATH, appIconPath);
+	}
+};

--- a/source/index.ts
+++ b/source/index.ts
@@ -72,7 +72,9 @@ let isQuitting = false;
 let prevMessageCount = 0;
 let dockMenu: Menu;
 
-if (!app.requestSingleInstanceLock()) {
+// TODO: Remove `!is.macAppStore &&` once the following issue is resolved:
+// https://github.com/electron/electron/issues/15958
+if (!is.macAppStore && !app.requestSingleInstanceLock()) {
 	app.quit();
 }
 


### PR DESCRIPTION
Hi @sindresorhus,

This PR should fix the issues you encountered when submitting the app to the Mac App Store (https://github.com/sindresorhus/caprine/issues/88).

The reason the app crashed on launch is the following bug in Electron related to instance locks: https://github.com/electron/electron/issues/15958. I've therefore disabled the instance lock for the MAS build.

I also added some missing configuration for `electron-builder` to the `package.json` file. The signed app now works as expected for me.