### PR TITLE
Remove unnecessary lines between items on the conversation list

### DIFF
--- a/css/vibrancy.css
+++ b/css/vibrancy.css
@@ -47,11 +47,6 @@ html.sidebar-vibrancy .__6l {
 	background-color: transparent !important;
 }
 
-/* Contact list: person container */
-html.sidebar-vibrancy ._1qt4 {
-	border-top: solid 1px rgba(0, 0, 0, 0.06);
-}
-
 /* Message container + right sidebar */
 html.sidebar-vibrancy ._4_j4,
 html.sidebar-vibrancy ._4_j5 {


### PR DESCRIPTION
Partially fixes​ #878

Before:

<img width="294" alt="Screenshot 2019-05-30 at 21 17 47" src="https://user-images.githubusercontent.com/374864/58658377-af9ced00-8320-11e9-9845-1b3752289918.png">


After:

<img width="298" alt="Screenshot 2019-05-30 at 21 18 25" src="https://user-images.githubusercontent.com/374864/58658381-b1ff4700-8320-11e9-8c43-2a8cdc981b01.png">