### PR TITLE
Fix too strong chat title bar bottom border

### DIFF
--- a/css/vibrancy.css
+++ b/css/vibrancy.css
@@ -34,8 +34,8 @@ html.sidebar-vibrancy.dark-mode ._5iwm ._58al {
 /* Chat title bar */
 html.sidebar-vibrancy ._673w {
 	background-color: #fff !important;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
+
 html.sidebar-vibrancy.dark-mode ._673w {
 	background-color: var(--container-dark-color) !important;
 	border-bottom: 1px solid var(--base-five) !important;


### PR DESCRIPTION
Partially fixes​ #878

Before:

<img width="537" alt="Screenshot 2019-05-30 at 21 22 39" src="https://user-images.githubusercontent.com/374864/58658717-66996880-8321-11e9-8646-3ea7a7453e3b.png">


After:

<img width="366" alt="Screenshot 2019-05-30 at 21 23 22" src="https://user-images.githubusercontent.com/374864/58658723-69945900-8321-11e9-8da4-68122f5ea572.png">