### PR TITLE
Fixes initial chat list dark background

### DIFF
--- a/css/vibrancy.css
+++ b/css/vibrancy.css
@@ -1,12 +1,5 @@
 /* -- BLOCK START: sidebar-only vibrancy -- */
 
-html.sidebar-vibrancy body,
-html.sidebar-vibrancy ._4sp8,
-html.sidebar-vibrancy.dark-mode body,
-html.sidebar-vibrancy.dark-mode ._4sp8 {
-	background: transparent !important;
-}
-
 /* Login screen */
 html.sidebar-vibrancy ._3v_o {
 	background-color: #fff;
@@ -24,9 +17,6 @@ html.sidebar-vibrancy.dark-mode ._36ic {
 }
 
 /* Contact list: search input */
-html.sidebar-vibrancy ._5iwm ._58al {
-	background-color: rgba(246, 247, 249, 0.5) !important;
-}
 html.sidebar-vibrancy.dark-mode ._5iwm ._58al {
 	background: var(--base-five) !important;
 }


### PR DESCRIPTION
I believe it's a bug: when I start Caprine my chat list has a dark gray background and when I hit CMD+R it reloads nicely to white one. This PR fixes this behavior and the list is white from the start.

Before:

<img width="310" alt="Screenshot 2019-05-30 at 21 26 41" src="https://user-images.githubusercontent.com/374864/58659115-6c437e00-8322-11e9-8129-086759f5e309.png">

After:

<img width="308" alt="Screenshot 2019-05-30 at 21 29 55" src="https://user-images.githubusercontent.com/374864/58659123-71083200-8322-11e9-8045-23a09a540bde.png">
