### PR TITLE
Fix emoji picker

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -317,7 +317,7 @@ body.show-message-buttons ._4_j4 ._39bj {
 	left: 100px;
 }
 
-/* Workaround work emoji selector #831 */
+/* Workaround for emoji selector issues/831 */
 @keyframes nodeInserted {
 	from {
 		opacity: 0.99;

--- a/css/browser.css
+++ b/css/browser.css
@@ -317,7 +317,7 @@ body.show-message-buttons ._4_j4 ._39bj {
 	left: 100px;
 }
 
-/* Workaround for emoji selector issues/831 */
+/* Workaround for emoji selector issue #831 */
 @keyframes nodeInserted {
 	from {
 		opacity: 0.99;

--- a/css/browser.css
+++ b/css/browser.css
@@ -316,3 +316,19 @@ body.show-message-buttons ._4_j4 ._39bj {
 	position: relative;
 	left: 100px;
 }
+
+/* Workaround work emoji selector #831 */
+@keyframes nodeInserted {
+	from {
+		opacity: 0.99;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+._5s2p {
+	/* stylelint-disable-next-line */
+	animation-duration: 0.001s;
+	animation-name: nodeInserted;
+}

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -117,8 +117,10 @@ ipc.on('insert-gif', () => {
 	document.querySelector<HTMLElement>('._yht')!.click();
 });
 
-ipc.on('insert-emoji', () => {
-	document.querySelector<HTMLElement>('._5s2p')!.click();
+ipc.on('insert-emoji', async () => {
+	const emojiEl = await elementReady<HTMLElement>('._5s2p');
+
+	emojiEl.click();
 });
 
 ipc.on('insert-text', () => {
@@ -419,11 +421,22 @@ function closePreferences(): void {
 	doneButton.click();
 }
 
+async function insertionListener(event: AnimationEvent): Promise<void> {
+	if (event.animationName === 'nodeInserted') {
+		const emojiEl = await elementReady<HTMLElement>('._5s2p');
+
+		emojiEl.dispatchEvent(new Event('mouseover', {bubbles: true}));
+	}
+}
+
 // Inject a global style node to maintain custom appearance after conversation change or startup
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
 	const style = document.createElement('style');
 	style.id = 'zoomFactor';
 	document.body.append(style);
+
+	const emojiContainer = await elementReady<HTMLElement>('._1t2u._7sli');
+	emojiContainer.addEventListener('animationstart', insertionListener, false);
 
 	// Set the zoom factor if it was set before quitting
 	const zoomFactor = config.get('zoomFactor') || 1;

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -118,9 +118,9 @@ ipc.on('insert-gif', () => {
 });
 
 ipc.on('insert-emoji', async () => {
-	const emojiEl = await elementReady<HTMLElement>('._5s2p');
+	const emojiElement = await elementReady<HTMLElement>('._5s2p');
 
-	emojiEl.click();
+	emojiElement.click();
 });
 
 ipc.on('insert-text', () => {
@@ -423,9 +423,9 @@ function closePreferences(): void {
 
 async function insertionListener(event: AnimationEvent): Promise<void> {
 	if (event.animationName === 'nodeInserted') {
-		const emojiEl = await elementReady<HTMLElement>('._5s2p');
+		const emojiElement = await elementReady<HTMLElement>('._5s2p');
 
-		emojiEl.dispatchEvent(new Event('mouseover', {bubbles: true}));
+		emojiElement.dispatchEvent(new Event('mouseover', {bubbles: true}));
 	}
 }
 

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -422,21 +422,19 @@ function closePreferences(): void {
 }
 
 async function insertionListener(event: AnimationEvent): Promise<void> {
-	if (event.animationName === 'nodeInserted') {
-		const emojiElement = await elementReady<HTMLElement>('._5s2p');
-
-		emojiElement.dispatchEvent(new Event('mouseover', {bubbles: true}));
+	if (event.animationName === 'nodeInserted' && event.target) {
+		event.target.dispatchEvent(new Event('mouseover', {bubbles: true}));
 	}
 }
 
+// Listen for emoji element dom insertion
+document.addEventListener('animationstart', insertionListener, false);
+
 // Inject a global style node to maintain custom appearance after conversation change or startup
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('DOMContentLoaded', () => {
 	const style = document.createElement('style');
 	style.id = 'zoomFactor';
 	document.body.append(style);
-
-	const emojiContainer = await elementReady<HTMLElement>('._1t2u._7sli');
-	emojiContainer.addEventListener('animationstart', insertionListener, false);
 
 	// Set the zoom factor if it was set before quitting
 	const zoomFactor = config.get('zoomFactor') || 1;


### PR DESCRIPTION
Fixes #831 

@sindresorhus 	@CvX 

Issue is pretty much explained [here](https://github.com/sindresorhus/caprine/issues/831#issuecomment-498070981) by @CvX 

Explanation: Triggering `mouseover` fetches the popover module. When switching conversations, the emoji component unmounts and needs `mouseover` in order to function correctly with the keyboard shortcut.`Mutation Observer` is clunky and heavy on performance since we can't listen directly on the node we require. Polling is also unreliable.

I think this one is consistent & the most performant. Please have a look.Thanks!


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#831: Bug with emoji selector](https://issuehunt.io/repos/42574339/issues/831)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->