### PR TITLE
WIP: Reload mainWindow on system resume

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -8,6 +8,7 @@ import {
 	screen as electronScreen,
 	session,
 	shell,
+	powerMonitor,
 	BrowserWindow,
 	Menu,
 	Notification,
@@ -331,6 +332,12 @@ function createMainWindow(): BrowserWindow {
 	enableHiresResources();
 
 	const {webContents} = mainWindow;
+
+	powerMonitor.on('resume', async () => {
+		await ensureOnline();
+
+		mainWindow.reload();
+	});
 
 	webContents.on('dom-ready', async () => {
 		await updateAppMenu();


### PR DESCRIPTION
Fixes #103 

@sindresorhus 

Right now it only checks for connection on `resume` and reloads the mainWindow.
What other behaviour would we like? I checked and `Messenger` already keeps the current message & focus. Keeping it `WIP` for now.