### PR TITLE
Add setting to hide the tray icon

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -18,8 +18,8 @@ const defaults = {
 		y: undefined as number | undefined
 	},
 	menuBarMode: false,
-	hideDockIcon: false,
-	hideTrayIcon: false,
+	showDockIcon: true,
+	showTrayIcon: true,
 	alwaysOnTop: false,
 	bounceDockOnMessage: false,
 	showUnreadBadge: true,

--- a/source/config.ts
+++ b/source/config.ts
@@ -19,6 +19,7 @@ const defaults = {
 	},
 	menuBarMode: false,
 	hideDockIcon: false,
+	hideTrayIcon: false,
 	alwaysOnTop: false,
 	bounceDockOnMessage: false,
 	showUnreadBadge: true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -134,6 +134,16 @@ ipcMain.on('update-overlay-icon', (_event: ElectronEvent, data: string, text: st
 	mainWindow.setOverlayIcon(img, text);
 });
 
+function updateTrayIcon(): void {
+	if (config.get('hideTrayIcon') || config.get('quitOnWindowClose')) {
+		tray.destroy();
+	} else {
+		tray.create(mainWindow);
+	}
+}
+
+ipcMain.on('update-tray-icon', updateTrayIcon);
+
 interface BeforeSendHeadersResponse {
 	cancel?: boolean;
 	requestHeaders?: RequestHeaders;

--- a/source/index.ts
+++ b/source/index.ts
@@ -135,7 +135,7 @@ ipcMain.on('update-overlay-icon', (_event: ElectronEvent, data: string, text: st
 });
 
 function updateTrayIcon(): void {
-	if (config.get('hideTrayIcon') || config.get('quitOnWindowClose')) {
+	if (!config.get('showTrayIcon') || config.get('quitOnWindowClose')) {
 		tray.destroy();
 	} else {
 		tray.create(mainWindow);
@@ -330,7 +330,7 @@ function createMainWindow(): BrowserWindow {
 		app.dock.setMenu(dockMenu);
 
 		// Dock icon is hidden initially on macOS
-		if (!config.get('hideDockIcon')) {
+		if (config.get('showDockIcon')) {
 			app.dock.show();
 		}
 

--- a/source/menu-bar-mode.ts
+++ b/source/menu-bar-mode.ts
@@ -35,7 +35,7 @@ export function toggleMenuBarMode(window: BrowserWindow): void {
 export function setUpMenuBarMode(window: BrowserWindow): void {
 	if (is.macos) {
 		toggleMenuBarMode(window);
-	} else {
+	} else if (!config.get('hideTrayIcon') && !config.get('quitOnWindowClose')) {
 		tray.create(window);
 	}
 }

--- a/source/menu-bar-mode.ts
+++ b/source/menu-bar-mode.ts
@@ -35,7 +35,7 @@ export function toggleMenuBarMode(window: BrowserWindow): void {
 export function setUpMenuBarMode(window: BrowserWindow): void {
 	if (is.macos) {
 		toggleMenuBarMode(window);
-	} else if (!config.get('hideTrayIcon') && !config.get('quitOnWindowClose')) {
+	} else if (config.get('showTrayIcon') && !config.get('quitOnWindowClose')) {
 		tray.create(window);
 	}
 }

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -256,12 +256,12 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
-			label: 'Hide Tray Icon',
+			label: 'Show Tray Icon',
 			type: 'checkbox',
 			enabled: is.linux || is.windows,
-			checked: config.get('hideTrayIcon'),
+			checked: config.get('showTrayIcon'),
 			click() {
-				config.set('hideTrayIcon', !config.get('hideTrayIcon'));
+				config.set('showTrayIcon', !config.get('showTrayIcon'));
 				sendAction('toggle-tray-icon');
 			}
 		},

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -256,12 +256,23 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			label: 'Hide Tray Icon',
+			type: 'checkbox',
+			enabled: is.linux || is.windows,
+			checked: config.get('hideTrayIcon'),
+			click() {
+				config.set('hideTrayIcon', !config.get('hideTrayIcon'));
+				sendAction('toggle-tray-icon');
+			}
+		},
+		{
 			label: 'Launch Minimized',
 			type: 'checkbox',
 			visible: !is.macos,
 			checked: config.get('launchMinimized'),
 			click() {
 				config.set('launchMinimized', !config.get('launchMinimized'));
+				sendAction('toggle-tray-icon');
 			}
 		},
 		{

--- a/source/tray.ts
+++ b/source/tray.ts
@@ -33,20 +33,20 @@ export default {
 						}
 					},
 					{
-						label: 'Hide Dock Icon',
+						label: 'Show Dock Icon',
 						type: 'checkbox',
-						checked: config.get('hideDockIcon'),
+						checked: config.get('showDockIcon'),
 						click(menuItem) {
-							config.set('hideDockIcon', menuItem.checked);
+							config.set('showDockIcon', menuItem.checked);
 
 							if (menuItem.checked) {
-								app.dock.hide();
-							} else {
 								app.dock.show();
+							} else {
+								app.dock.hide();
 							}
 
 							const dockMenuItem = contextMenu.getMenuItemById('dockMenu');
-							dockMenuItem.visible = menuItem.checked;
+							dockMenuItem.visible = !menuItem.checked;
 						}
 					},
 					{
@@ -55,7 +55,7 @@ export default {
 					{
 						id: 'dockMenu',
 						label: 'Menu',
-						visible: config.get('hideDockIcon'),
+						visible: !config.get('showDockIcon'),
 						submenu: Menu.getApplicationMenu()!
 					}
 			  ]


### PR DESCRIPTION
Fixes #684 

@sindresorhus 

I've closed the previous PR, had some issue with those commits, #800 

To summarize:

- Added `Show Tray Icon` menu item, Defaults to `true`
- If `quitOnWindowClose` is `true` or `showTrayIcon` is `false`, don't create tray or `destroy()` already created tray

Thanks!

