### PR TITLE
Fix white plus bar, removed report bug icon

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -332,3 +332,8 @@ body.show-message-buttons ._4_j4 ._39bj {
 	animation-duration: 0.001s;
 	animation-name: nodeInserted;
 }
+
+/* Report bug icon on contact list */
+._4_xe {
+	display: none;
+}

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -850,3 +850,8 @@ html.dark-mode ._30yy._6-xp._6-xq {
 html.dark-mode ._5irm._7mkm {
 	background: var(--container-color);
 }
+
+/* Additional "plus" bar */
+html.dark-mode ._7mkk._7t1o._7t0e {
+	background: var(--container-color);
+}

--- a/css/vibrancy.css
+++ b/css/vibrancy.css
@@ -221,4 +221,8 @@ html.full-vibrancy ._5irm._7mkm {
 	background: transparent;
 }
 
+/* Additional "plus" bar */
+html.full-vibrancy ._7mkk._7t1o._7t0j {
+	display: none;
+}
 /* -- BLOCK END: full-window vibrancy -- */


### PR DESCRIPTION
Problem does not exists for everyone, I've got new messenger version only on one device.

# Before fix
<img width="1130" alt="2" src="https://user-images.githubusercontent.com/10632503/60113504-31423800-9772-11e9-896c-eb77157370a7.png">
<img width="1129" alt="4" src="https://user-images.githubusercontent.com/10632503/60113505-31423800-9772-11e9-9cee-705d75ae5d59.png">

# After fix
<img width="1126" alt="1" src="https://user-images.githubusercontent.com/10632503/60113521-399a7300-9772-11e9-9aed-05695b7ca4b0.png">
<img width="1128" alt="3" src="https://user-images.githubusercontent.com/10632503/60113523-399a7300-9772-11e9-9d6a-9f21a198843b.png">
