### PR TITLE
Fix dragging scrollbar when app is zoomed

### DIFF
--- a/source/browser/selectors.ts
+++ b/source/browser/selectors.ts
@@ -1,4 +1,4 @@
 export default {
 	conversationList: 'div[role="navigation"] > div > ul',
-	conversationSelector: '._4u-c._1wfr > ._5f0v.uiScrollableArea'
+	conversationSelector: '._4u-c._1wfr .__i_, ._4u-c._1wfr #conversationWindow'
 };


### PR DESCRIPTION
@sindresorhus 

Fixes #765 

The scrollbar from the conversation list has a weird behaviour when the `zoom` property is applied on the parent container.
I could not reproduce this in a separate environment. It may be related to `electron` and/or `messenger`.

The workaround is to apply `zoom` on the content (without the scrollbar).I've also updated the `conversationSelector` with a fallback.