### PR TITLE
Fix Facebook logo placement

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -345,3 +345,8 @@ body.show-message-buttons ._4_j4 ._7mkk {
 ._4_xe {
 	display: none;
 }
+
+/* Facebook logo */
+._4kny {
+	margin-left: 70px;
+}


### PR DESCRIPTION
This PR supposed to fix the issue when FB needs to re-authenticate you due changed location. That happened to me today. Unfortunately I am not able to force FB to do it again, so can't test it after restoring the app.

<img width="912" alt="Screenshot 2019-06-29 at 22 20 05" src="https://user-images.githubusercontent.com/374864/60389001-ec4c3780-9aca-11e9-871d-d643fc744c20.png">


