### PR TITLE
Improve cropping for system emoji on some Linux systems

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -291,8 +291,9 @@ ipc.on('render-native-emoji', (_event: ElectronEvent, emoji: string) => {
 		context.font = '256px system-ui';
 		context.fillText(emoji, 128, 154);
 	} else {
+		context.textBaseline = 'bottom';
 		context.font = '225px system-ui';
-		context.fillText(emoji, 128, 115);
+		context.fillText(emoji, 128, 256);
 	}
 
 	const dataUrl = canvas.toDataURL();


### PR DESCRIPTION
I have a cropping issue (emojis are rendered too far up) when using my system font, ttf-joypixels on Arch Linux. This change fixes it for me, but I'm not in a position to test if it breaks things for other systems/font packages.