### PR TITLE
Set placeholder text to the correct color on macOS when in dark mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -235,6 +235,12 @@ html.dark-mode ._1wc4 {
 	border-top-color: var(--base-ten);
 }
 
+/* Message composer: placeholder text */
+html.dark-mode ._4rv3 ._1p1v {
+	color: var(--base-thirty);
+	-webkit-text-fill-color: var(--base-thirty);
+}
+
 /* Contact list: header above */
 html.dark-mode ._36ic {
 	background: var(--list-header-color) !important;


### PR DESCRIPTION
I think `-webkit-text-fill-color` is required on macOS electron apps, it looks like. Adding this rule fixes the issue. This should fix #1001, at least on macOS

<details><summary>Before</summary>

![Screen Shot 2019-07-25 at 1 47 14 PM](https://user-images.githubusercontent.com/2652762/61896755-99a44680-aee3-11e9-9bb6-d84d5e25780a.png)

</details>

<details><summary>After</summary>

![Screen Shot 2019-07-25 at 1 47 22 PM](https://user-images.githubusercontent.com/2652762/61896765-9dd06400-aee3-11e9-90e3-fd7c8e3f648b.png)


</details>