### PR TITLE
Fix schema validation crash

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -30,12 +30,10 @@ const schema: {[key: string]: JSONSchema} = {
 		type: 'object',
 		properties: {
 			width: {
-				type: 'number',
-				default: 800
+				type: 'number'
 			},
 			height: {
-				type: 'number',
-				default: 600
+				type: 'number'
 			},
 			x: {
 				type: 'number'
@@ -43,6 +41,12 @@ const schema: {[key: string]: JSONSchema} = {
 			y: {
 				type: 'number'
 			}
+		},
+		default: {
+			width: 800,
+			height: 600,
+			x: undefined,
+			y: undefined
 		}
 	},
 	menuBarMode: {
@@ -88,17 +92,19 @@ const schema: {[key: string]: JSONSchema} = {
 		type: 'object',
 		properties: {
 			chatSeen: {
-				type: 'boolean',
-				default: false
+				type: 'boolean'
 			},
 			typingIndicator: {
-				type: 'boolean',
-				default: false
+				type: 'boolean'
 			},
 			deliveryReceipt: {
-				type: 'boolean',
-				default: false
+				type: 'boolean'
 			}
+		},
+		default: {
+			chatSeen: false,
+			typingIndicator: false,
+			deliveryReceipt: false
 		}
 	},
 	emojiStyle: {

--- a/source/ensure-online.ts
+++ b/source/ensure-online.ts
@@ -3,17 +3,13 @@ import isOnline from 'is-online';
 import pWaitFor from 'p-wait-for';
 
 function showWaitDialog(): void {
-	const buttonIndex = dialog.showMessageBoxSync(
-		// @ts-ignore
-		undefined,
-		{
-			message: 'You appear to be offline. Caprine requires a working internet connection.',
-			detail: 'Do you want to wait?',
-			buttons: ['Wait', 'Quit'],
-			defaultId: 0,
-			cancelId: 1
-		}
-	);
+	const buttonIndex = dialog.showMessageBoxSync({
+		message: 'You appear to be offline. Caprine requires a working internet connection.',
+		detail: 'Do you want to wait?',
+		buttons: ['Wait', 'Quit'],
+		defaultId: 0,
+		cancelId: 1
+	});
 
 	if (buttonIndex === 1) {
 		app.quit();

--- a/source/util.ts
+++ b/source/util.ts
@@ -21,17 +21,13 @@ export function sendBackgroundAction(action: string, ...args: unknown[]): void {
 }
 
 export function showRestartDialog(message: string): void {
-	const buttonIndex = dialog.showMessageBoxSync(
-		// @ts-ignore
-		undefined,
-		{
-			message,
-			detail: 'Do you want to restart the app now?',
-			buttons: ['Restart', 'Ignore'],
-			defaultId: 0,
-			cancelId: 1
-		}
-	);
+	const buttonIndex = dialog.showMessageBoxSync({
+		message,
+		detail: 'Do you want to restart the app now?',
+		buttons: ['Restart', 'Ignore'],
+		defaultId: 0,
+		cancelId: 1
+	});
 
 	if (buttonIndex === 0) {
 		app.relaunch();


### PR DESCRIPTION
@sindresorhus 	Fixes #1031

I could not reproduce #1034, I've checked and all enum values are valid. It might be that the config file was edited/corrupted/had old values before the schema was introduced which would explain an app crash. Should be fixed by a clean install / config reset.