### PR TITLE
Document that Linux supports `Alt` to toggle menu bar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ Mute conversation      | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>m</kbd
 Archive conversation   | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>a</kbd>
 Delete conversation    | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>d</kbd>
 Toggle "Always on Top" | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>t</kbd>
-Toggle window menu     | <kbd>Alt</kbd> *(Windows only)*
+Toggle window menu     | <kbd>Alt</kbd> *(Windows/Linux only)*
 Toggle main window     | <kbd>Command</kbd> <kbd>Shift</kbd> <kbd>y</kbd> *(macOS only)*
 Toggle sidebar         | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>s</kbd>
 Switch to Messenger    | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>1</kbd>


### PR DESCRIPTION
Pressing "Alt" will toggle the menu bar in (at least) the most common desktop environments. Fixes #208.

Simple change to Readme.