### PR TITLE
Work around the vibrancy issue

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -469,7 +469,7 @@ function createMainWindow(): BrowserWindow {
 
 if (is.macos) {
 	ipcMain.on('set-vibrancy', () => {
-		mainWindow.setBackgroundColor('#00000000'); // Transparent
+		mainWindow.setBackgroundColor('#00000000'); // Transparent, workaround for vibrancy issue.
 		mainWindow.setVibrancy('sidebar');
 
 		if (config.get('followSystemAppearance')) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -469,6 +469,7 @@ function createMainWindow(): BrowserWindow {
 
 if (is.macos) {
 	ipcMain.on('set-vibrancy', () => {
+		mainWindow.setBackgroundColor('#00000000'); // Transparent
 		mainWindow.setVibrancy('sidebar');
 
 		if (config.get('followSystemAppearance')) {


### PR DESCRIPTION
This PR tries to work around the vibrancy issue.

Vibrancy effect is still missing:
- when docked Dev Tools are present
- in a brief time window (~3 seconds) after a navigation/reload

Before/After

<img src="https://user-images.githubusercontent.com/66961/64011990-15b22f80-cb1d-11e9-8a64-0c99746cae5c.gif" alt="before" width=300> <img src="https://user-images.githubusercontent.com/66961/64012662-67a78500-cb1e-11e9-8eb0-839fe38b786a.gif" alt="after" width=300>

Closes #1056
Closes #1052
Closes #712