### PR TITLE
Fix the GIF search field background

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -376,6 +376,11 @@ body.show-message-buttons ._4_j4 ._7mkk {
 	background: transparent !important;
 }
 
+/* GIF search field */
+._3mtr ._4qcs {
+	background: transparent !important;
+}
+
 /* -- BLOCK START: Private Mode -- */
 /* Contact list: person name */
 html.private-mode ._1ht6 {


### PR DESCRIPTION
Fixes #1098 

Before:

<img src="https://user-images.githubusercontent.com/66961/66270083-ae8c4700-e84f-11e9-955a-6b24dd44cba2.png" width="212" alt="before">

After:

<img src="https://user-images.githubusercontent.com/66961/66270058-784ec780-e84f-11e9-85c4-784f660d7de1.png" width="212" alt="after">
