### PR TITLE
Fix "require admin approval" dark mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -399,6 +399,11 @@ html.dark-mode ._3x6v {
 	color: var(--base-fourty);
 }
 
+/* Right sidebar: require admin approval */
+html.dark-mode ._3ihp {
+	color: var(--base-fourty);
+}
+
 /* Right sidebar: people list */
 html.dark-mode ._4_j5 ._5l37 {
 	color: var(--base-fourty);


### PR DESCRIPTION
Fixes #1103 unreadable text in group settings.
**After**
![image](https://user-images.githubusercontent.com/6593380/66757427-7498f180-ee9c-11e9-90c7-1d129ea6ec39.png)
