### PR TITLE
Fix "Insert Text" keyboard shortcut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ Jump to conversation   | <kbd>Command/Control</kbd> <kbd>1</kbd>…<kbd>9</kbd>
 Insert GIF             | <kbd>Command/Control</kbd> <kbd>g</kbd>
 Insert sticker         | <kbd>Command/Control</kbd> <kbd>s</kbd>
 Insert emoji           | <kbd>Command/Control</kbd> <kbd>e</kbd>
-Insert text            | <kbd>Command/Control</kbd> <kbd>i</kbd>
+Focus text input       | <kbd>Command/Control</kbd> <kbd>i</kbd>
 Search in conversation | <kbd>Command/Control</kbd> <kbd>f</kbd>
 Mute conversation      | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>m</kbd>
 Archive conversation   | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>a</kbd>

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -153,7 +153,7 @@ ipc.on('insert-sticker', () => {
 	stickerElement!.click();
 });
 
-ipc.on('insert-text', () => {
+ipc.on('focus-text-input', () => {
 	document.querySelector<HTMLElement>('._7kpg ._5rpu')!.focus();
 });
 

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -154,7 +154,7 @@ ipc.on('insert-sticker', () => {
 });
 
 ipc.on('insert-text', () => {
-	document.querySelector<HTMLElement>('._5rpu')!.focus();
+	document.querySelector<HTMLElement>('._7kpg ._5rpu')!.focus();
 });
 
 ipc.on('next-conversation', nextConversation);

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -508,10 +508,10 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
-			label: 'Insert Text',
+			label: 'Focus Text Input',
 			accelerator: 'CommandOrControl+I',
 			click() {
-				sendAction('insert-text');
+				sendAction('focus-text-input');
 			}
 		}
 	];


### PR DESCRIPTION
The selector for the "Insert Text" keyboard is not specific enough, it focuses the wrong textbox some times (for example when having the "search" feature open in a group chat).

* I've made the selector more specific.
* I also renamed "Insert Text" to "Focus Textbox" https://github.com/sindresorhus/caprine/pull/1014#discussion_r310539228
  * I chose "Focus Textbox" over "Focus Text Input" for brevity. Can rename if wanted.