### PR TITLE
Fix group avatar being squished

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -143,6 +143,11 @@ html.sidebar-hidden ._1enh {
 	display: block !important;
 }
 
+/* Makes group avatar visible in small window */
+._6ynm {
+	min-width: 40px !important;
+}
+
 /* Vertically center chat options */
 ._fl2 {
 	padding: 0 !important;


### PR DESCRIPTION
Fixes group image stretching when width of window is small.
Resolves #1116 

Before: image sizes down because it has set just width and height. But when window sized down, image stretch badly.

After: image remains same size when widnos sizes down