### PR TITLE
Fix some dark mode styles

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -510,7 +510,8 @@ html.dark-mode ._34n6 {
 
 /* Message reaction buttons */
 html.dark-mode ._aou,
-html.dark-mode ._4kf5 {
+html.dark-mode ._4kf5,
+html.dark-mode ._3s-4 {
 	background-color: var(--container-color);
 }
 
@@ -830,6 +831,36 @@ html.dark-mode ._7i2n {
 /* More message icon */
 html.dark-mode ._7i2l {
 	filter: invert(1);
+}
+
+/* Sidebar > Options: search and nicknames icons */
+html.dark-mode ._6y56,
+html.dark-mode ._6ybv {
+	filter: invert(1);
+}
+
+/* Sidebar > Options: edit group picture hover */
+html.dark-mode ._80co {
+	background: none;
+}
+
+html.dark-mode ._7101:hover ._7q1j {
+	opacity: 0.5;
+}
+
+html.dark-mode ._80co form div a {
+	filter: invert(1);
+}
+
+/* "replied to" message label */
+html.dark-mode ._3egs {
+	background: none;
+}
+
+/* Remove profile picture border */
+html.dark-mode [aria-label='Conversation List'] [aria-hidden='true'] > div > div,
+html.dark-mode [role='main'] > span > div div[style^='border:'] {
+	border-color: transparent !important;
 }
 
 /* "Delete message" popup */


### PR DESCRIPTION
This introduces some dark mode style consistency fixes. The changes are:

* dark background behind reaction in reaction popup
* light icons in Sidebar > Options menu
* dark background on hover in Sidebar > Edit group picture
* removed white border on profile pictures
* dark "replied to" label on message replies

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/8854330/67114925-a236b100-f1a2-11e9-9645-5176046db676.png)
![image](https://user-images.githubusercontent.com/8854330/67114959-ba0e3500-f1a2-11e9-9039-5b5f3d350233.png)

## After

![image](https://user-images.githubusercontent.com/8854330/67115104-06f20b80-f1a3-11e9-857a-d58f385b92c8.png)
![image](https://user-images.githubusercontent.com/8854330/67115134-1b360880-f1a3-11e9-9992-51addde45703.png)
