### PR TITLE
Fix "Attach Files" keyboard shortcut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ Jump to conversation   | <kbd>Command/Control</kbd> <kbd>1</kbd>…<kbd>9</kbd>
 Insert GIF             | <kbd>Command/Control</kbd> <kbd>g</kbd>
 Insert sticker         | <kbd>Command/Control</kbd> <kbd>s</kbd>
 Insert emoji           | <kbd>Command/Control</kbd> <kbd>e</kbd>
-Attach files           | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>a</kbd>
+Attach files           | <kbd>Command/Control</kbd> <kbd>t</kbd>
 Focus text input       | <kbd>Command/Control</kbd> <kbd>i</kbd>
 Search in conversation | <kbd>Command/Control</kbd> <kbd>f</kbd>
 Mute conversation      | <kbd>Command/Control</kbd> <kbd>Shift</kbd> <kbd>m</kbd>

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -517,7 +517,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 		},
 		{
 			label: 'Attach Files',
-			accelerator: 'CommandOrControl+Shift+A',
+			accelerator: 'CommandOrControl+T',
 			click() {
 				sendAction('attach-files');
 			}


### PR DESCRIPTION
Was happy to see v2.40.0 released, with the new "Attach Files" keyboard shortcut :smile: Good work :beers: 

Was eager to try "Attach Files", and it works, though not well.

`CommandOrControl+Shift+A` requires two presses before activating at my system. I'm guessing that the key combination conflicts with something.

I'm proposing to change it to `CommandOrControl+T` to make it work in one key press. Any other combination is fine as well, as long as it works.