### PR TITLE
Fix disabled contact name in dark mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -344,6 +344,11 @@ html.dark-mode ._4_j5 {
 	border-left: solid 1px var(--base-five);
 }
 
+/* Right sidebar: disabled contact name */
+html.dark-mode ._3eur {
+	color: var(--base-seventy);
+}
+
 /* Right sidebar: contact name */
 html.dark-mode ._3eur a {
 	color: var(--blue);


### PR DESCRIPTION
Resolves #1132 
When Facebook account is disabled you can still use messenger, but the name is not <a> so it looks bad in dark mode.