### PR TITLE
Fix group notification icons in dark mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -879,12 +879,6 @@ html.dark-mode ._497p ._uwa {
 	filter: invert(1);
 }
 
-/* Sidebar > Options: search and nicknames icons */
-html.dark-mode ._6y56,
-html.dark-mode ._6ybv {
-	filter: invert(1);
-}
-
 /* Sidebar > Options: edit group picture hover */
 html.dark-mode ._80co {
 	background: none;

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -846,6 +846,11 @@ html.dark-mode ._7i2l {
 	filter: invert(1);
 }
 
+/* Group chat notification icons */
+html.dark-mode ._497p ._uwa {
+	filter: invert(1);
+}
+
 /* Sidebar > Options: search and nicknames icons */
 html.dark-mode ._6y56,
 html.dark-mode ._6ybv {


### PR DESCRIPTION
I found that all icons in group chat on the left side before notification has this xpath "._497p ._uwa". So I inverted all of them, because facebook icon sprite can change anytime and searching white on each icon would be lot of work with every sprite change.

Resolves: #883 

after:
![image](https://user-images.githubusercontent.com/6593380/67631790-148e4c00-f89b-11e9-98e7-032ca46ce32a.png)
