### PR TITLE
Fix `Always on Top` after tray toggling on KDE Plasma

### DIFF
--- a/source/menu.ts
+++ b/source/menu.ts
@@ -233,6 +233,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 		},
 		{
 			label: 'Always on Top',
+			id: 'always-on-top',
 			type: 'checkbox',
 			accelerator: 'CommandOrControl+Shift+T',
 			checked: config.get('alwaysOnTop'),

--- a/source/tray.ts
+++ b/source/tray.ts
@@ -20,6 +20,8 @@ export default {
 				win.hide();
 			} else {
 				win.show();
+				// Workaround for https://github.com/electron/electron/issues/20858
+				// setAlwaysOnTop stops working after hiding window on KDE Plasma
 				const alwaysOnTopMenuItem = Menu.getApplicationMenu()!.getMenuItemById('always-on-top');
 				win.setAlwaysOnTop(alwaysOnTopMenuItem.checked);
 			}

--- a/source/tray.ts
+++ b/source/tray.ts
@@ -20,8 +20,9 @@ export default {
 				win.hide();
 			} else {
 				win.show();
+
 				// Workaround for https://github.com/electron/electron/issues/20858
-				// setAlwaysOnTop stops working after hiding window on KDE Plasma
+				// `setAlwaysOnTop` stops working after hiding the window on KDE Plasma.
 				const alwaysOnTopMenuItem = Menu.getApplicationMenu()!.getMenuItemById('always-on-top');
 				win.setAlwaysOnTop(alwaysOnTopMenuItem.checked);
 			}

--- a/source/tray.ts
+++ b/source/tray.ts
@@ -20,6 +20,8 @@ export default {
 				win.hide();
 			} else {
 				win.show();
+				const alwaysOnTopMenuItem = Menu.getApplicationMenu()!.getMenuItemById('always-on-top');
+				win.setAlwaysOnTop(alwaysOnTopMenuItem.checked);
 			}
 		}
 


### PR DESCRIPTION
It fixes bug on linux with KDE Plasma that after toggling to and from tray 'Always on Top' setting stops working despite it is still checked.