### PR TITLE
Update to Electron 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,39 @@
 				"ajv-keywords": "^3.1.0"
 			}
 		},
+		"@electron/get": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-1.6.0.tgz",
+			"integrity": "sha512-xuvAzbN9iBApfAMvW0hKUpxHR5wPVbG9RaoSTbpu/WaHISDu0MVfMWYhfeU0X730CpBV0G2RkLgwAs9WDan3GA==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"global-agent": "^2.0.2",
+				"global-tunnel-ng": "^2.7.1",
+				"got": "^9.6.0",
+				"sanitize-filename": "^1.6.2",
+				"sumchecker": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -772,21 +805,6 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
-		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -802,12 +820,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
 			"integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
 		"atob": {
@@ -852,18 +864,6 @@
 					}
 				}
 			}
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
 		},
 		"bail": {
 			"version": "1.0.4",
@@ -932,15 +932,6 @@
 				}
 			}
 		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
 		"bluebird": {
 			"version": "3.5.5",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -955,6 +946,12 @@
 			"requires": {
 				"bluebird": "^3.5.5"
 			}
+		},
+		"boolean": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-2.0.2.tgz",
+			"integrity": "sha512-ymsbJQlux/uogyEWfsXJUYzuyoOzPyp6NvEV71s6/ptQR7ptKO9uHF+WZL2GRATDeN52EFhNyrIu+exNZKh3Cw==",
+			"dev": true
 		},
 		"boxen": {
 			"version": "3.2.0",
@@ -1264,12 +1261,6 @@
 			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
 			"dev": true
 		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
-		},
 		"ccount": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
@@ -1494,15 +1485,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1531,38 +1513,6 @@
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"conf": {
@@ -1682,6 +1632,17 @@
 				}
 			}
 		},
+		"config-chain": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
 		"configstore": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
@@ -1744,6 +1705,13 @@
 				"is-error": "^2.2.0"
 			}
 		},
+		"core-js": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
+			"integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
+			"dev": true,
+			"optional": true
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1795,15 +1763,6 @@
 			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
-			}
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-fns": {
@@ -2087,17 +2046,18 @@
 				}
 			}
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
-		},
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
 			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 			"dev": true
+		},
+		"detect-node": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+			"dev": true,
+			"optional": true
 		},
 		"dir-glob": {
 			"version": "2.2.2",
@@ -2251,16 +2211,6 @@
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
 		"ejs": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
@@ -2268,20 +2218,20 @@
 			"dev": true
 		},
 		"electron": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-6.0.11.tgz",
-			"integrity": "sha512-mi1oHmeFIQrg+CDQ6lbugZAloOxuWPm/ecEKYe1230PGlDoWND7SYStiWQ2eI4YXAEOL/NvuY88ogemu1qhdBg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-7.0.0.tgz",
+			"integrity": "sha512-vrF1loRW1p0vQCbduqO0EZpo8ePJOuxUT6tSoUSU3lsbGK3VnlJop+0PpCIPzbe2K4G4Gk7WexH08V9se7mJcA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "^10.12.18",
-				"electron-download": "^4.1.0",
+				"@electron/get": "^1.0.1",
+				"@types/node": "^12.0.12",
 				"extract-zip": "^1.0.3"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "10.14.20",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.20.tgz",
-					"integrity": "sha512-An+MXSV8CGXz/BO9C1KKsoJ/8WDrvlNUaRMsm2h+IHZuSyQkM8U5bJJkb8ItLKA73VePG/nUK+t+EuW2IWuhsQ==",
+					"version": "12.12.3",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
+					"integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
 					"dev": true
 				}
 			}
@@ -2414,40 +2364,6 @@
 				"ext-name": "^5.0.0",
 				"pupa": "^1.0.0",
 				"unused-filename": "^1.0.0"
-			}
-		},
-		"electron-download": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
-			"integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.0.0",
-				"env-paths": "^1.0.0",
-				"fs-extra": "^4.0.1",
-				"minimist": "^1.2.0",
-				"nugget": "^2.0.1",
-				"path-exists": "^3.0.0",
-				"rc": "^1.2.1",
-				"semver": "^5.4.1",
-				"sumchecker": "^2.0.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
 			}
 		},
 		"electron-is-accelerator": {
@@ -2606,6 +2522,13 @@
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
 		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"dev": true,
+			"optional": true
+		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -2636,9 +2559,9 @@
 			"dev": true
 		},
 		"env-paths": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-			"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
 			"dev": true
 		},
 		"error-ex": {
@@ -2686,6 +2609,13 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"optional": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -3655,12 +3585,6 @@
 				"yauzl": "2.4.1"
 			}
 		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
 		"facebook-locales": {
 			"version": "1.0.740",
 			"resolved": "https://registry.npmjs.org/facebook-locales/-/facebook-locales-1.0.740.tgz",
@@ -3831,23 +3755,6 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -3858,14 +3765,22 @@
 			}
 		},
 		"fs-extra": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
+				"graceful-fs": "^4.2.0",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+					"dev": true
+				}
 			}
 		},
 		"fs.realpath": {
@@ -3898,12 +3813,6 @@
 			"integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
 			"dev": true
 		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
-		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3917,15 +3826,6 @@
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"github-url-from-git": {
 			"version": "1.5.0",
@@ -3974,6 +3874,31 @@
 			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
 			"dev": true
 		},
+		"global-agent": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.5.tgz",
+			"integrity": "sha512-pYJjCxxNBzYxo6iNO62JZn8iCFVbvpiM0zE4w/G5hBNIvLjnvzIeCVQPMKc3aK8ju5L7Q8NNI/oBSosU0eeSYw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"boolean": "^2.0.2",
+				"core-js": "^3.3.3",
+				"es6-error": "^4.1.1",
+				"matcher": "^2.0.0",
+				"roarr": "^2.14.2",
+				"semver": "^6.3.0",
+				"serialize-error": "^5.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"global-dirs": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -4003,11 +3928,36 @@
 				"which": "^1.3.1"
 			}
 		},
+		"global-tunnel-ng": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
+			"integrity": "sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"encodeurl": "^1.0.2",
+				"lodash": "^4.17.10",
+				"npm-conf": "^1.1.3",
+				"tunnel": "^0.0.6"
+			}
+		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
+		},
+		"globalthis": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz",
+			"integrity": "sha512-vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"object-keys": "^1.0.12"
+			}
 		},
 		"globby": {
 			"version": "6.1.0",
@@ -4075,22 +4025,6 @@
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
 		},
 		"has": {
 			"version": "1.0.3",
@@ -4218,17 +4152,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
 			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
-			}
 		},
 		"husky": {
 			"version": "3.0.8",
@@ -4623,15 +4546,6 @@
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
-		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -4885,12 +4799,6 @@
 				"url-regex": "^5.0.0"
 			}
 		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
-		},
 		"is-whitespace-character": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
@@ -4922,9 +4830,9 @@
 			"dev": true
 		},
 		"isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
 		"isbinaryfile": {
@@ -4942,12 +4850,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
 		"issue-regex": {
@@ -4977,12 +4879,6 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4998,12 +4894,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
 		},
 		"json-schema-traverse": {
@@ -5026,7 +4916,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"json5": {
 			"version": "2.1.0",
@@ -5043,18 +4934,6 @@
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
 			}
 		},
 		"keyboardevent-from-electron-accelerator": {
@@ -5593,6 +5472,25 @@
 			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
 			"dev": true
 		},
+		"matcher": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+			"integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"mathml-tag-names": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
@@ -5702,15 +5600,6 @@
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
 			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-		},
-		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-			"dev": true,
-			"requires": {
-				"mime-db": "1.40.0"
-			}
 		},
 		"mimic-fn": {
 			"version": "2.1.0",
@@ -6284,6 +6173,26 @@
 				}
 			}
 		},
+		"npm-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"config-chain": "^1.1.11",
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"npm-name": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/npm-name/-/npm-name-5.4.0.tgz",
@@ -6334,21 +6243,6 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"nugget": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-			"integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-			"dev": true,
-			"requires": {
-				"debug": "^2.1.3",
-				"minimist": "^1.1.0",
-				"pretty-bytes": "^1.0.2",
-				"progress-stream": "^1.1.0",
-				"request": "^2.45.0",
-				"single-line-log": "^1.1.2",
-				"throttleit": "0.0.2"
-			}
-		},
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -6359,12 +6253,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"obj-props": {
@@ -6417,10 +6305,11 @@
 			"dev": true
 		},
 		"object-keys": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"optional": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -6767,12 +6656,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-			"dev": true
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
 		"picomatch": {
@@ -7128,180 +7011,6 @@
 				"fast-diff": "^1.1.2"
 			}
 		},
-		"pretty-bytes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-			"integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "^4.0.1",
-				"meow": "^3.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
-				}
-			}
-		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7314,15 +7023,12 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
-		"progress-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-			"integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true,
-			"requires": {
-				"speedometer": "~0.1.2",
-				"through2": "~0.2.3"
-			}
+			"optional": true
 		},
 		"proto-props": {
 			"version": "2.0.0",
@@ -7334,12 +7040,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"public-ip": {
@@ -7370,12 +7070,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pupa/-/pupa-1.0.0.tgz",
 			"integrity": "sha1-mpVopa9+ZXuEYqbp1TKHQ1YM7/Y="
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
 		},
 		"quick-lru": {
 			"version": "1.1.0",
@@ -7450,15 +7144,18 @@
 			}
 		},
 		"readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"redent": {
@@ -7596,48 +7293,11 @@
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
-		},
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
 			"dev": true
-		},
-		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -7751,6 +7411,30 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"roarr": {
+			"version": "2.14.3",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.3.tgz",
+			"integrity": "sha512-D4BpKVruUDCJ9DJWcC7T+fx4o10IUYJ7MdmjM4Skx1aqc42CE7LGzPDUAfczibhavNGcnY1IHqJdq16NmiG4rQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"boolean": "^2.0.2",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.0",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -7857,6 +7541,25 @@
 				"semver": "^5.0.3"
 			}
 		},
+		"serialize-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+			"integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"type-fest": "^0.8.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -7903,15 +7606,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
-		"single-line-log": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-			"integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.1"
-			}
 		},
 		"slash": {
 			"version": "3.0.0",
@@ -8127,12 +7821,6 @@
 			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
 			"dev": true
 		},
-		"speedometer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-			"integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
-			"dev": true
-		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -8155,23 +7843,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
 		},
 		"stat-mode": {
 			"version": "0.3.0",
@@ -8238,10 +7909,13 @@
 			}
 		},
 		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
 		},
 		"stringify-entities": {
 			"version": "1.3.2",
@@ -8498,12 +8172,29 @@
 			}
 		},
 		"sumchecker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
-			"integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.0.tgz",
+			"integrity": "sha512-yreseuC/z4iaodVoq07XULEOO9p4jnQazO7mbrnDSvWAU/y2cbyIKs+gWJptfcGu9R+1l27K8Rkj0bfvqnBpgQ==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.2.0"
+				"debug": "^4.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"supports-color": {
@@ -8674,27 +8365,11 @@
 			"integrity": "sha1-AIRwUAVzDdhNt1UlPJMa45jblSI=",
 			"dev": true
 		},
-		"throttleit": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-			"integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-			"dev": true
-		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
-		},
-		"through2": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-			"integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.1.9",
-				"xtend": "~2.1.1"
-			}
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -8769,24 +8444,6 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
-		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-			"dev": true,
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
-		},
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -8835,20 +8492,12 @@
 				"tslib": "^1.8.1"
 			}
 		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+		"tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
 			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
+			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -9129,12 +8778,6 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
-		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-			"dev": true
-		},
 		"v8-compile-cache": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
@@ -9158,17 +8801,6 @@
 			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
-			}
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
 			}
 		},
 		"vfile": {
@@ -9651,15 +9283,6 @@
 					"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
 					"dev": true
 				}
-			}
-		},
-		"xtend": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-			"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-			"dev": true,
-			"requires": {
-				"object-keys": "~0.4.0"
 			}
 		},
 		"y18n": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@typescript-eslint/eslint-plugin": "^2.3.3",
 		"@typescript-eslint/parser": "^2.3.3",
 		"del-cli": "^3.0.0",
-		"electron": "^6.0.11",
+		"electron": "^7.0.0",
 		"electron-builder": "^21.2.0",
 		"eslint-config-xo-typescript": "^0.19.0",
 		"husky": "^3.0.8",

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -12,16 +12,6 @@ import {memoize} from 'lodash';
 import config from './config';
 import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
 
-// TODO: removeListener is typed incorrectly in v7.0.0. Remove on later version
-// Issue: https://github.com/electron/electron/issues/20705
-// PR: https://github.com/electron/electron/pull/20712
-declare module 'electron' {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	class IpcMain {
-		removeListener(event: string, listener: (...args: any[]) => void): this;
-	}
-}
-
 // The list of emojis that aren't supported by older emoji (facebook-2-2, messenger-1-0)
 // Based on https://emojipedia.org/facebook/3.0/new/
 const excludedEmoji = new Set([

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -16,6 +16,7 @@ import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
 // Issue: https://github.com/electron/electron/issues/20705
 // PR: https://github.com/electron/electron/pull/20712
 declare module 'electron' {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	class IpcMain {
 		removeListener(event: string, listener: (...args: any[]) => void): this;
 	}

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -16,11 +16,10 @@ import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
 // Issue: https://github.com/electron/electron/issues/20705
 // PR: https://github.com/electron/electron/pull/20712
 declare module 'electron' {
-  class IpcMain {
-    removeListener(event: string, listener: (...args: any[]) => void): this;
-  }
+	class IpcMain {
+		removeListener(event: string, listener: (...args: any[]) => void): this;
+	}
 }
-
 
 // The list of emojis that aren't supported by older emoji (facebook-2-2, messenger-1-0)
 // Based on https://emojipedia.org/facebook/3.0/new/

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -12,6 +12,16 @@ import {memoize} from 'lodash';
 import config from './config';
 import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
 
+// TODO: removeListener is typed incorrectly in v7.0.0. Remove on later version
+// Issue: https://github.com/electron/electron/issues/20705
+// PR: https://github.com/electron/electron/pull/20712
+declare module 'electron' {
+  class IpcMain {
+    removeListener(event: string, listener: (...args: any[]) => void): this;
+  }
+}
+
+
 // The list of emojis that aren't supported by older emoji (facebook-2-2, messenger-1-0)
 // Based on https://emojipedia.org/facebook/3.0/new/
 const excludedEmoji = new Set([

--- a/source/index.ts
+++ b/source/index.ts
@@ -182,7 +182,7 @@ function enableHiresResources(): void {
 	session.defaultSession!.webRequest.onBeforeSendHeaders(
 		filter,
 		(details: OnSendHeadersDetails, callback: (response: BeforeSendHeadersResponse) => void) => {
-			let cookie = (details.requestHeaders as any).Cookie;
+			let cookie = details.requestHeaders.Cookie;
 
 			if (cookie && details.method === 'GET') {
 				if (/(?:; )?dpr=\d/.test(cookie)) {

--- a/source/index.ts
+++ b/source/index.ts
@@ -179,7 +179,7 @@ function enableHiresResources(): void {
 
 	const filter = {urls: [`*://*.${domain}/`]};
 
-	session.defaultSession!.webRequest.onBeforeSendHeaders(
+	session.defaultSession.webRequest.onBeforeSendHeaders(
 		filter,
 		(details: OnSendHeadersDetails, callback: (response: BeforeSendHeadersResponse) => void) => {
 			let cookie = details.requestHeaders.Cookie;
@@ -214,7 +214,7 @@ function initRequestsFiltering(): void {
 		]
 	};
 
-	session.defaultSession!.webRequest.onBeforeRequest(filter, async ({url}, callback) => {
+	session.defaultSession.webRequest.onBeforeRequest(filter, async ({url}, callback) => {
 		if (url.includes('emoji.php')) {
 			callback(await processEmojiUrl(url));
 		} else if (url.includes('typ.php')) {
@@ -235,7 +235,7 @@ function setUserLocale(): void {
 		value: userLocale
 	};
 
-	session.defaultSession!.cookies.set(cookie);
+	session.defaultSession.cookies.set(cookie);
 }
 
 function setNotificationsMute(status: boolean): void {
@@ -462,9 +462,10 @@ function createMainWindow(): BrowserWindow {
 				options.show = true;
 				options.titleBarStyle = 'default';
 				if (options.webPreferences !== undefined) {
-					options.webPreferences.nodeIntegration = false
+					options.webPreferences.nodeIntegration = false;
 					options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
 				}
+
 				(event as any).newGuest = new BrowserWindow(options);
 			}
 		} else {

--- a/source/index.ts
+++ b/source/index.ts
@@ -453,7 +453,7 @@ function createMainWindow(): BrowserWindow {
 		);
 	});
 
-	webContents.on('new-window', (event: Event, url, frameName, _disposition, options) => {
+	webContents.on('new-window', async (event: Event, url, frameName, _disposition, options) => {
 		event.preventDefault();
 
 		if (url === 'about:blank') {
@@ -472,11 +472,11 @@ function createMainWindow(): BrowserWindow {
 				url = new URL(url).searchParams.get('u')!;
 			}
 
-			shell.openExternalSync(url);
+			await shell.openExternal(url);
 		}
 	});
 
-	webContents.on('will-navigate', (event, url) => {
+	webContents.on('will-navigate', async (event, url) => {
 		const isMessengerDotCom = (url: string): boolean => {
 			const {hostname} = new URL(url);
 			return hostname.endsWith('.messenger.com');
@@ -515,7 +515,7 @@ function createMainWindow(): BrowserWindow {
 		}
 
 		event.preventDefault();
-		shell.openExternalSync(url);
+		await shell.openExternal(url);
 	});
 })();
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -461,8 +461,10 @@ function createMainWindow(): BrowserWindow {
 				// Voice/video call popup
 				options.show = true;
 				options.titleBarStyle = 'default';
-				options.webPreferences.nodeIntegration = false;
-				options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
+				if (options.webPreferences !== undefined) {
+					options.webPreferences.nodeIntegration = false
+					options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
+				}
 				(event as any).newGuest = new BrowserWindow(options);
 			}
 		} else {

--- a/source/index.ts
+++ b/source/index.ts
@@ -13,7 +13,6 @@ import {
 	Notification,
 	MenuItemConstructorOptions,
 	Event as ElectronEvent,
-	RequestHeaders,
 	OnSendHeadersDetails
 } from 'electron';
 import log from 'electron-log';
@@ -156,7 +155,7 @@ ipcMain.on('update-tray-icon', updateTrayIcon);
 
 interface BeforeSendHeadersResponse {
 	cancel?: boolean;
-	requestHeaders?: RequestHeaders;
+	requestHeaders?: Record<string, string>;
 }
 
 function enableHiresResources(): void {

--- a/source/index.ts
+++ b/source/index.ts
@@ -463,11 +463,9 @@ function createMainWindow(): BrowserWindow {
 				// Voice/video call popup
 				options.show = true;
 				options.titleBarStyle = 'default';
-				if (options.webPreferences !== undefined) {
-					options.webPreferences.nodeIntegration = false;
-					options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
-				}
-
+				options.webPreferences = options.webPreferences || {};
+				options.webPreferences.nodeIntegration = false;
+				options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
 				(event as any).newGuest = new BrowserWindow(options);
 			}
 		} else {

--- a/source/index.ts
+++ b/source/index.ts
@@ -12,8 +12,7 @@ import {
 	Menu,
 	Notification,
 	MenuItemConstructorOptions,
-	Event as ElectronEvent,
-	OnSendHeadersDetails
+	Event as ElectronEvent
 } from 'electron';
 import log from 'electron-log';
 import {autoUpdater} from 'electron-updater';
@@ -156,6 +155,17 @@ ipcMain.on('update-tray-icon', updateTrayIcon);
 interface BeforeSendHeadersResponse {
 	cancel?: boolean;
 	requestHeaders?: Record<string, string>;
+}
+
+interface OnSendHeadersDetails {
+	id: number;
+	url: string;
+	method: string;
+	webContentsId?: number;
+	resourceType: string;
+	referrer: string;
+	timestamp: number;
+	requestHeaders: Record<string, string>;
 }
 
 function enableHiresResources(): void {


### PR DESCRIPTION
I was complaining about a system vibrancy problem in #1091 and it was indicated that to fix the issue properly on Catalina it was necessary to wait for the next version of Electron to be released. It was indeed released a week ago.

This PR updates the version and then fixes the errors that I saw running `npm install && npm start`.

(It does not appear to fix my original complaint, any additional work will go in another branch)