### PR TITLE
Resize media and embeds for narrow windows

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -437,7 +437,35 @@ html.private-mode ._1htf > span:first-child {
 
 /* -- BLOCK START: Small conversations window -- */
 
+/* Restrict media width to viewport */
+._3zvs div[role='presentation'] > div, /* photos and GIFs */
+._53j5 /* videos */ {
+	width: auto !important;
+	height: auto !important;
+}
+
+._53j5 video {
+	width: auto !important;
+	height: auto !important;
+	max-width: 100%;
+}
+
 @media (max-width: 500px) {
+	/* Inline event preview */
+	._51mx > td {
+		display: block;
+	}
+
+	/* Event title description */
+	._2pij {
+		padding-right: 0 !important;
+	}
+
+	/* Event action buttons (Interested) */
+	.hRght {
+		margin-top: 12px;
+	}
+
 	._20bp {
 		flex-direction: column !important;
 	}


### PR DESCRIPTION
Limits photo, video, and GIF widths so they don't overflow horizontally. Also shuffles around UI for inline event previews:

<img width="278" alt="image" src="https://user-images.githubusercontent.com/8854330/68344169-ffdc6000-00b3-11ea-841a-7f5daafc139d.png">

becomes

<img width="278" alt="image" src="https://user-images.githubusercontent.com/8854330/68344095-d91e2980-00b3-11ea-9939-f8bb305d038a.png">

This is similar to the changes in PR #861 (closed unmerged) and fixes #851, fixes #859, and fixes #1066.