### PR TITLE
Add ability to force sidebar width

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -87,6 +87,16 @@ html.hide-dropdowns .uiContextualLayerPositioner {
 /* SIDEBAR                       */
 /* ***************************** */
 
+/* Narrow view */
+@media (max-width: 900px) {
+	/* Icons area */
+	html:not(.sidebar-force-wide) ._6-xk {
+		height: auto;
+		padding-top: 36px;
+		flex-direction: column;
+	}
+}
+
 /* Hide sidebar (optionally) */
 html.sidebar-hidden ._1enh {
 	visibility: hidden;
@@ -94,6 +104,88 @@ html.sidebar-hidden ._1enh {
 	max-width: 0;
 	width: 0;
 	height: 0;
+}
+html.sidebar-hidden.os-darwin ._6ynl {
+	padding-left: 76px;
+}
+
+/* Forced slim sidebar (copied from @media (max-width: 900px) blocks) */
+
+html.sidebar-force-slim ._1ht5 ._1qt4._7vuo,
+html.sidebar-force-slim ._6-xk ._6-xo,
+html.sidebar-force-slim ._6-xv,
+html.sidebar-force-slim ._6-xl,
+html.sidebar-force-slim ._7sta._87u_,
+html.sidebar-force-slim ._1nq2._7vup,
+html.sidebar-force-slim ._6ymu,
+html.sidebar-force-slim ._1ht1 ._2j6._6zkg {
+	display: none;
+}
+html.sidebar-force-slim ._1enh._7q1s {
+	flex-basis: 74px;
+	min-width: 80px;
+}
+html.sidebar-force-slim ._6-xk {
+	justify-content: center;
+}
+html.sidebar-force-slim ._6-xp {
+	margin-left: 0;
+}
+html.sidebar-force-slim ._6zkc {
+	padding-left: 4px;
+	padding-right: 4px;
+}
+html.sidebar-force-slim ._7t1l {
+	justify-content: center;
+}
+html.sidebar-force-slim ._1ht1 ._1qt3._6-5k {
+	margin-right: 0;
+}
+html.sidebar-force-slim ._1ht3._1ht1._6zk9 {
+	background-color: rgba(0, 132, 255, 0.2);
+	transition: background-color 0.5s;
+}
+html.sidebar-force-slim ._1ht1._6zk9._1ht2 {
+	transition: background-color 0.5s;
+}
+html.sidebar-force-slim ._7vuq {
+	display: block;
+}
+/* Copied from "Narrow view" block above */
+html.sidebar-force-slim ._6-xk {
+	height: auto;
+	padding-top: 36px;
+	flex-direction: column;
+}
+
+/* Forced wide sidebar (restores default styles overwritten by media query) */
+html.sidebar-force-wide ._1nq2._7vup,
+html.sidebar-force-wide ._1ht1 ._2j6._6zkg {
+	display: block;
+}
+html.sidebar-force-wide ._1enh._7q1s {
+	flex-basis: 25%;
+	min-width: 285px;
+}
+html.sidebar-force-wide ._6-xp {
+	margin-left: auto;
+}
+html.sidebar-force-wide ._6zkc {
+	padding-left: 8px;
+	padding-right: 8px;
+}
+html.sidebar-force-wide ._7t1l {
+	justify-content: normal;
+}
+html.sidebar-force-wide ._1ht1 ._1qt3._6-5k {
+	margin-right: 12px;
+}
+html.sidebar-force-wide ._1ht3._1ht1._6zk9 {
+	background: none;
+}
+html.sidebar-force-wide ._1ht5 ._1qt4._7vuo,
+html.sidebar-force-wide ._7vuq {
+	display: flex;
 }
 
 /* Hide sidebar title */
@@ -125,16 +217,6 @@ html.sidebar-hidden ._1enh {
 /* macOS: Move the contextual back button so it's not obstructed by the native traffic lights */
 .os-darwin ._30yy._2oc9 {
 	margin-left: 65px !important;
-}
-
-/* Narrow view */
-@media (max-width: 900px) {
-	/* Icons area */
-	._6-xk {
-		height: auto !important;
-		padding-top: 36px !important;
-		flex-direction: column;
-	}
 }
 
 /* ***************************** */

--- a/css/browser.css
+++ b/css/browser.css
@@ -109,50 +109,50 @@ html.sidebar-hidden.os-darwin ._6ynl {
 	padding-left: 76px;
 }
 
-/* Forced slim sidebar (copied from @media (max-width: 900px) blocks) */
+/* Forced narrow sidebar (copied from @media (max-width: 900px) blocks) */
 
-html.sidebar-force-slim ._1ht5 ._1qt4._7vuo,
-html.sidebar-force-slim ._6-xk ._6-xo,
-html.sidebar-force-slim ._6-xv,
-html.sidebar-force-slim ._6-xl,
-html.sidebar-force-slim ._7sta._87u_,
-html.sidebar-force-slim ._1nq2._7vup,
-html.sidebar-force-slim ._6ymu,
-html.sidebar-force-slim ._1ht1 ._2j6._6zkg {
+html.sidebar-force-narrow ._1ht5 ._1qt4._7vuo,
+html.sidebar-force-narrow ._6-xk ._6-xo,
+html.sidebar-force-narrow ._6-xv,
+html.sidebar-force-narrow ._6-xl,
+html.sidebar-force-narrow ._7sta._87u_,
+html.sidebar-force-narrow ._1nq2._7vup,
+html.sidebar-force-narrow ._6ymu,
+html.sidebar-force-narrow ._1ht1 ._2j6._6zkg {
 	display: none;
 }
-html.sidebar-force-slim ._1enh._7q1s {
+html.sidebar-force-narrow ._1enh._7q1s {
 	flex-basis: 74px;
 	min-width: 80px;
 }
-html.sidebar-force-slim ._6-xk {
+html.sidebar-force-narrow ._6-xk {
 	justify-content: center;
 }
-html.sidebar-force-slim ._6-xp {
+html.sidebar-force-narrow ._6-xp {
 	margin-left: 0;
 }
-html.sidebar-force-slim ._6zkc {
+html.sidebar-force-narrow ._6zkc {
 	padding-left: 4px;
 	padding-right: 4px;
 }
-html.sidebar-force-slim ._7t1l {
+html.sidebar-force-narrow ._7t1l {
 	justify-content: center;
 }
-html.sidebar-force-slim ._1ht1 ._1qt3._6-5k {
+html.sidebar-force-narrow ._1ht1 ._1qt3._6-5k {
 	margin-right: 0;
 }
-html.sidebar-force-slim ._1ht3._1ht1._6zk9 {
+html.sidebar-force-narrow ._1ht3._1ht1._6zk9 {
 	background-color: rgba(0, 132, 255, 0.2);
 	transition: background-color 0.5s;
 }
-html.sidebar-force-slim ._1ht1._6zk9._1ht2 {
+html.sidebar-force-narrow ._1ht1._6zk9._1ht2 {
 	transition: background-color 0.5s;
 }
-html.sidebar-force-slim ._7vuq {
+html.sidebar-force-narrow ._7vuq {
 	display: block;
 }
 /* Copied from "Narrow view" block above */
-html.sidebar-force-slim ._6-xk {
+html.sidebar-force-narrow ._6-xk {
 	height: auto;
 	padding-top: 36px;
 	flex-direction: column;

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -186,12 +186,6 @@ ipc.on('hide-conversation', async () => {
 	}
 });
 
-function setSidebarVisibility(): void {
-	document.documentElement.classList.toggle('sidebar-hidden', config.get('sidebarHidden'));
-
-	ipc.send('set-sidebar-visibility');
-}
-
 async function openHiddenPreferences(): Promise<boolean> {
 	if (!isPreferencesOpen()) {
 		const style = document.createElement('style');
@@ -314,6 +308,27 @@ function updateVibrancy(): void {
 	ipc.send('set-vibrancy');
 }
 
+function updateSidebar(): void {
+	const {classList} = document.documentElement;
+
+	classList.remove('sidebar-hidden', 'sidebar-force-slim', 'sidebar-force-wide');
+
+	switch (config.get('sidebar')) {
+		case 'hidden':
+			classList.add('sidebar-hidden');
+			break;
+		case 'slim':
+			classList.add('sidebar-force-slim');
+			break;
+		case 'wide':
+			classList.add('sidebar-force-wide');
+			break;
+		default:
+	}
+
+	ipc.send('set-sidebar');
+}
+
 async function updateDoNotDisturb(): Promise<void> {
 	const shouldClosePreferences = await openHiddenPreferences();
 	const soundsCheckbox = document.querySelector<HTMLInputElement>(messengerSoundsSelector)!;
@@ -344,9 +359,8 @@ function renderOverlayIcon(messageCount: number): HTMLCanvasElement {
 	return canvas;
 }
 
-ipc.on('toggle-sidebar', () => {
-	config.set('sidebarHidden', !config.get('sidebarHidden'));
-	setSidebarVisibility();
+ipc.on('update-sidebar', () => {
+	updateSidebar();
 });
 
 ipc.on('set-dark-mode', setDarkMode);
@@ -546,8 +560,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 	// Enable OS specific styles
 	document.documentElement.classList.add(`os-${process.platform}`);
 
-	// Hide sidebar if it was hidden before quitting
-	setSidebarVisibility();
+	// Restore sidebar view state to what is was set before quitting
+	updateSidebar();
 
 	// Activate Dark Mode if it was set before quitting
 	setDarkMode();

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -311,14 +311,14 @@ function updateVibrancy(): void {
 function updateSidebar(): void {
 	const {classList} = document.documentElement;
 
-	classList.remove('sidebar-hidden', 'sidebar-force-slim', 'sidebar-force-wide');
+	classList.remove('sidebar-hidden', 'sidebar-force-narrow', 'sidebar-force-wide');
 
 	switch (config.get('sidebar')) {
 		case 'hidden':
 			classList.add('sidebar-hidden');
 			break;
-		case 'slim':
-			classList.add('sidebar-force-slim');
+		case 'narrow':
+			classList.add('sidebar-force-narrow');
 			break;
 		case 'wide':
 			classList.add('sidebar-force-wide');

--- a/source/config.ts
+++ b/source/config.ts
@@ -30,7 +30,7 @@ type StoreType = {
 	};
 	emojiStyle: 'native' | 'facebook-3-0' | 'messenger-1-0' | 'facebook-2-2';
 	useWorkChat: boolean;
-	sidebar: 'default' | 'hidden' | 'slim' | 'wide';
+	sidebar: 'default' | 'hidden' | 'narrow' | 'wide';
 	autoHideMenuBar: boolean;
 	notificationsMuted: boolean;
 	hardwareAcceleration: boolean;
@@ -155,7 +155,7 @@ const schema: {[Key in keyof StoreType]: Store.Schema} = {
 	},
 	sidebar: {
 		type: 'string',
-		enum: ['default', 'hidden', 'slim', 'wide'],
+		enum: ['default', 'hidden', 'narrow', 'wide'],
 		default: 'default'
 	},
 	autoHideMenuBar: {
@@ -196,8 +196,17 @@ function updateVibrancySetting(store: Store): void {
 	}
 }
 
+function updateSidebarSetting(store: Store): void {
+	if (store.get('sidebarHidden')) {
+		store.set('sidebar', 'hidden');
+	} else {
+		store.set('sidebar', 'default');
+	}
+}
+
 function migrate(store: Store): void {
 	updateVibrancySetting(store);
+	updateSidebarSetting(store);
 }
 
 const store = new Store<StoreType>({schema});

--- a/source/config.ts
+++ b/source/config.ts
@@ -30,7 +30,7 @@ type StoreType = {
 	};
 	emojiStyle: 'native' | 'facebook-3-0' | 'messenger-1-0' | 'facebook-2-2';
 	useWorkChat: boolean;
-	sidebarHidden: boolean;
+	sidebar: 'default' | 'hidden' | 'slim' | 'wide';
 	autoHideMenuBar: boolean;
 	notificationsMuted: boolean;
 	hardwareAcceleration: boolean;
@@ -153,9 +153,10 @@ const schema: {[Key in keyof StoreType]: Store.Schema} = {
 		type: 'boolean',
 		default: false
 	},
-	sidebarHidden: {
-		type: 'boolean',
-		default: false
+	sidebar: {
+		type: 'string',
+		enum: ['default', 'hidden', 'slim', 'wide'],
+		default: 'default'
 	},
 	autoHideMenuBar: {
 		type: 'boolean',

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -86,6 +86,51 @@ export default async function updateMenu(): Promise<Menu> {
 		}
 	];
 
+	const sidebarSubmenu: MenuItemConstructorOptions[] = [
+		{
+			label: 'Adaptive Sidebar',
+			type: 'checkbox',
+			checked: config.get('sidebar') === 'default',
+			async click() {
+				config.set('sidebar', 'default');
+				sendAction('update-sidebar');
+				await updateMenu();
+			}
+		},
+		{
+			label: 'Hide Sidebar',
+			type: 'checkbox',
+			checked: config.get('sidebar') === 'hidden',
+			accelerator: 'CommandOrControl+Shift+S',
+			async click() {
+				// Toggle between default and hidden
+				config.set('sidebar', config.get('sidebar') === 'hidden' ? 'default' : 'hidden');
+				sendAction('update-sidebar');
+				await updateMenu();
+			}
+		},
+		{
+			label: 'Slim Sidebar',
+			type: 'checkbox',
+			checked: config.get('sidebar') === 'slim',
+			async click() {
+				config.set('sidebar', 'slim');
+				sendAction('update-sidebar');
+				await updateMenu();
+			}
+		},
+		{
+			label: 'Wide Sidebar',
+			type: 'checkbox',
+			checked: config.get('sidebar') === 'wide',
+			async click() {
+				config.set('sidebar', 'wide');
+				sendAction('update-sidebar');
+				await updateMenu();
+			}
+		}
+	];
+
 	const privacySubmenu: MenuItemConstructorOptions[] = [
 		{
 			label: 'Block Seen Indicator',
@@ -409,13 +454,8 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			type: 'separator'
 		},
 		{
-			label: 'Show Sidebar',
-			type: 'checkbox',
-			checked: !config.get('sidebarHidden'),
-			accelerator: 'CommandOrControl+Shift+S',
-			click() {
-				sendAction('toggle-sidebar');
-			}
+			label: 'Sidebar',
+			submenu: sidebarSubmenu
 		},
 		{
 			label: 'Show Message Buttons',

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -110,11 +110,11 @@ export default async function updateMenu(): Promise<Menu> {
 			}
 		},
 		{
-			label: 'Slim Sidebar',
+			label: 'Narrow Sidebar',
 			type: 'checkbox',
-			checked: config.get('sidebar') === 'slim',
+			checked: config.get('sidebar') === 'narrow',
 			async click() {
-				config.set('sidebar', 'slim');
+				config.set('sidebar', 'narrow');
 				sendAction('update-sidebar');
 				await updateMenu();
 			}


### PR DESCRIPTION
Adds the ability to change between different sidebar widths (fixes #297). Let's you choose between:

* adaptive (default, changes with window size)
* hidden (same as before, hides sidebar completely, fixed to move group text title out of the way of MacOS traffic lights)
* narrow (force narrow-screen sidebar on all window sizes)
* wide (force wide-screen sidebar on all window sizes)

<img width="444" alt="image" src="https://user-images.githubusercontent.com/8854330/68356641-71c6a080-00d8-11ea-8aa1-e59b20473235.png">

I wasn't sure on how to keep the toggle sidebar keyboard shortcut, so I made the menu item to hide the sidebar act as toggle. This might be unconventional, let me know if there is a better way.