### PR TITLE
Fix hidden 360 photos

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -526,7 +526,7 @@ html.private-mode ._1htf > span:first-child {
 /* -- BLOCK START: Small conversations window -- */
 
 /* Restrict media width to viewport */
-._3zvs div[role='presentation'] > div, /* photos and GIFs */
+._3zvs div[role='presentation'] > div:not(._64e6), /* photos and GIFs without 360 photos*/
 ._53j5 /* videos */ {
 	width: auto !important;
 	height: auto !important;


### PR DESCRIPTION
After #1167 360 photos don't have minimal width and height.
So I removed 360 class from being set width|height = auto !important.