### PR TITLE
Fix “Hide conversation” menu item

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -508,7 +508,7 @@ In other words, you should only use this function within a callback
  makes sure to have the conversation menu open before executing the
  callback and closes the conversation menu afterward.
 */
-function isSelectedConversationGroup(): Boolean {
+function isSelectedConversationGroup(): boolean {
 	const separator = document.querySelector<HTMLElement>(
 		`${conversationMenuSelector} > li:nth-child(6)[role=separator]`
 	);

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -51,7 +51,7 @@ async function withSettingsMenu(callback: () => Promise<void> | void): Promise<v
 
 function selectMenuItem(itemNumber: number): void {
 	const selector = document.querySelector<HTMLElement>(
-		`.uiLayer:not(.hidden_elem) ._54nq._2i-c._558b._2n_z li:nth-child(${itemNumber}) a`
+		`.uiLayer:not(.hidden_elem) [role=menu] > li:nth-child(${itemNumber}) a`
 	);
 
 	if (selector) {
@@ -483,7 +483,7 @@ function setZoom(zoomFactor: number): void {
 
 async function withConversationMenu(callback: () => void): Promise<void> {
 	const menuButton = document.querySelector<HTMLElement>(
-		`${selectedConversationSelector} ._5blh._4-0h`
+		`${selectedConversationSelector} [aria-haspopup=true] [role=button]`
 	);
 
 	if (menuButton) {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -500,13 +500,10 @@ async function openMuteModal(): Promise<void> {
 
 /*
 This function assumes:
- - There is a currently selected conversation.
- - That conversation already has its conversation menu open.
+- There is a selected conversation.
+- That the conversation already has its conversation menu open.
 
-In other words, you should only use this function within a callback
- that is provided to withConversationMenu() because withConversationMenu()
- makes sure to have the conversation menu open before executing the
- callback and closes the conversation menu afterward.
+In other words, you should only use this function within a callback that is provided to `withConversationMenu()`, because `withConversationMenu()` makes sure to have the conversation menu open before executing the callback and closes the conversation menu afterwards.
 */
 function isSelectedConversationGroup(): boolean {
 	const separator = document.querySelector<HTMLElement>(

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -9,6 +9,7 @@ import {createConversationList} from './browser/conversation-list';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 const preferencesSelector = '._10._4ebx.uiLayer._4-hy';
 const messengerSoundsSelector = `${preferencesSelector} ._374d ._6bkz`;
+const conversationMenuSelector = '.uiLayer:not(.hidden_elem) [role=menu]';
 
 async function withMenu(
 	menuButtonElement: HTMLElement,
@@ -51,7 +52,7 @@ async function withSettingsMenu(callback: () => Promise<void> | void): Promise<v
 
 function selectMenuItem(itemNumber: number): void {
 	const selector = document.querySelector<HTMLElement>(
-		`.uiLayer:not(.hidden_elem) [role=menu] > li:nth-child(${itemNumber}) a`
+		`${conversationMenuSelector} > li:nth-child(${itemNumber}) a`
 	);
 
 	if (selector) {
@@ -497,25 +498,32 @@ async function openMuteModal(): Promise<void> {
 	});
 }
 
-async function hideSelectedConversation(): Promise<void> {
-	const groupConversationProfilePicture = document.querySelector<HTMLElement>(
-		`${selectedConversationSelector} ._55lu`
-	);
-	const isGroupConversation = Boolean(groupConversationProfilePicture);
+/*
+This function assumes:
+ - There is a currently selected conversation.
+ - That conversation already has its conversation menu open.
 
+In other words, you should only use this function within a callback
+ that is provided to withConversationMenu() because withConversationMenu()
+ makes sure to have the conversation menu open before executing the
+ callback and closes the conversation menu afterward.
+*/
+function isSelectedConversationGroup(): Boolean {
+	const separator = document.querySelector<HTMLElement>(
+		`${conversationMenuSelector} > li:nth-child(6)[role=separator]`
+	);
+	return Boolean(separator);
+}
+
+async function hideSelectedConversation(): Promise<void> {
 	await withConversationMenu(() => {
-		selectMenuItem(isGroupConversation ? 4 : 3);
+		selectMenuItem(isSelectedConversationGroup() ? 4 : 3);
 	});
 }
 
 async function deleteSelectedConversation(): Promise<void> {
-	const groupConversationProfilePicture = document.querySelector<HTMLElement>(
-		`${selectedConversationSelector} ._55lu`
-	);
-	const isGroupConversation = Boolean(groupConversationProfilePicture);
-
 	await withConversationMenu(() => {
-		selectMenuItem(isGroupConversation ? 5 : 4);
+		selectMenuItem(isSelectedConversationGroup() ? 5 : 4);
 	});
 }
 


### PR DESCRIPTION
Fixes #1027 

Right now, the “Hide conversation” menu item (AKA the archive button) does not work. This was because of some CSS selectors seem to have become outdated. I have replaced them as follows:

1. `.uiLayer:not(.hidden_elem) ._54nq._2i-c._558b._2n_z` → `.uiLayer:not(.hidden_elem) [role=menu]`
1. `${selectedConversationSelector} ._5blh._4-0h` → `${selectedConversationSelector} [aria-haspopup=true] [role=button]`

Note that the new selectors do not rely on minified class names like `_5blh` but rather on descriptive attributes like `[role=button]`. Hopefully, this means that these new selectors will be less likely to break with changes made to the Messenger website by Facebook.

Note also that I have tried to avoid using any localized attributes, so hopefully this works for all messenger.com localizations.