### PR TITLE
Prevent user from hiding tray icon when the Launch Minimized option i…

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -1,7 +1,7 @@
 import Store = require('electron-store');
 import {is} from 'electron-util';
 
-type StoreType = {
+export type StoreType = {
 	followSystemAppearance: boolean;
 	darkMode: boolean;
 	privateMode: boolean;

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -10,7 +10,7 @@ import {
 	debugInfo
 } from 'electron-util';
 import config from './config';
-import {sendAction, showRestartDialog} from './util';
+import {sendAction, showRestartDialog, disableMenuItem} from './util';
 import {generateSubmenu as generateEmojiSubmenu} from './emoji';
 import {toggleMenuBarMode} from './menu-bar-mode';
 import {caprineIconPath} from './constants';
@@ -329,9 +329,10 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			id: 'showTrayIcon',
 			label: 'Show Tray Icon',
 			type: 'checkbox',
-			enabled: is.linux || is.windows,
+			enabled: (is.linux || is.windows) && !config.get('launchMinimized'),
 			checked: config.get('showTrayIcon'),
 			click() {
 				config.set('showTrayIcon', !config.get('showTrayIcon'));
@@ -345,7 +346,23 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			checked: config.get('launchMinimized'),
 			click() {
 				config.set('launchMinimized', !config.get('launchMinimized'));
-				sendAction('toggle-tray-icon');
+				const showTrayIconItem = menu.getMenuItemById('showTrayIcon');
+
+				if(config.get('launchMinimized')) {
+					disableMenuItem({
+						menuItem: showTrayIconItem,
+						configKey: 'showTrayIcon',
+						value: true
+					});
+
+					dialog.showMessageBox({
+						type: 'info',
+						message: 'Show Tray Icon option has been locked on enabled due to enabled Launch Minimized option.',
+						buttons: ['OK']
+					});
+				} else {
+					showTrayIconItem.enabled = true;
+				}
 			}
 		},
 		{

--- a/source/util.ts
+++ b/source/util.ts
@@ -1,6 +1,6 @@
 import {app, BrowserWindow, dialog} from 'electron';
 import {is} from 'electron-util';
-import config from './config';
+import config, {StoreType}  from './config';
 
 export function getWindow(): BrowserWindow {
 	const [win] = BrowserWindow.getAllWindows();
@@ -48,4 +48,13 @@ export function stripTrackingFromUrl(url: string): string {
 	}
 
 	return url;
+}
+
+export function disableMenuItem(
+	{menuItem, configKey, value}:
+	{menuItem: Electron.MenuItem, configKey: keyof StoreType, value: boolean}): void {
+		config.set(configKey, value);
+
+		menuItem.enabled = false;
+		menuItem.checked = value;
 }


### PR DESCRIPTION
…s enabled.

System: Windows 7

Fixed problem:
I've noticed that Show Tray Icon and Launch Minimized options can be mutually exclusive. 
To reproduce the problem, set:
-File->Caprine Settings->Show Tray Icon on false
-File->Caprine Settings->Launch Minimized on the true
then close application and open it again. The process is running but you have no way to maximize the app window.

I've resolved this problem by enforcing Show Tray Icon on enabled when Launch Minimized is enabled.