### PR TITLE
Fix a bug that prevents the tray icon from showing

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -436,6 +436,7 @@ function createMainWindow(): BrowserWindow {
 
 		if (config.get('launchMinimized') || app.getLoginItemSettings().wasOpenedAsHidden) {
 			mainWindow.hide();
+			tray.create(mainWindow);
 		} else {
 			mainWindow.show();
 		}


### PR DESCRIPTION
…lose is enabled.

System: Windows 7

Fixed Problem: 
I've noticed that when Quit on Window Close option is enabled tray icon is not showing after restarting the application.

To reproduce the problem, set:
File->Caprine Settings->Show Tray Icon on true
File->Caprine Settings->Quit on Window Close on true
then close applications and open it again. The tray icon is not showing.