### PR TITLE
Fix issue where people list item color was not selected

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -456,7 +456,8 @@ html.dark-mode ._5rh4 {
 /* Right sidebar: people list item (name) */
 html.dark-mode ._364g,
 html.dark-mode ._3x6u,
-html.dark-mode ._4rph ._4rpj {
+html.dark-mode ._4rph ._4rpj
+html.dark-mode ._5l38._42ef ._8slc {
 	color: var(--base-seventy);
 }
 

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -456,7 +456,7 @@ html.dark-mode ._5rh4 {
 /* Right sidebar: people list item (name) */
 html.dark-mode ._364g,
 html.dark-mode ._3x6u,
-html.dark-mode ._4rph ._4rpj
+html.dark-mode ._4rph ._4rpj,
 html.dark-mode ._5l38._42ef ._8slc {
 	color: var(--base-seventy);
 }


### PR DESCRIPTION
Fixed issue where the person list item text color was being applied with `color: var(--base-seventy);`. This should fix the issue in any popups displaying the same list item as well.

Tested on Windows 10.

Before:
![image](https://user-images.githubusercontent.com/2801187/70858200-70ed0f80-1ecb-11ea-8e45-b17ec4e3d81c.png)

After:
![image](https://user-images.githubusercontent.com/2801187/70858202-777b8700-1ecb-11ea-9cab-14da94dcc4bf.png)
