### PR TITLE
Fix an issue where emoji & messenger preferences menus don't open (macOS)

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -4,7 +4,7 @@ import elementReady = require('element-ready');
 import selectors from './browser/selectors';
 import config from './config';
 import {toggleVideoAutoplay} from './autoplay';
-import {createConversationList} from './browser/conversation-list';
+import './browser/conversation-list';
 
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 const preferencesSelector = '._10._4ebx.uiLayer._4-hy';
@@ -276,16 +276,11 @@ function setDarkMode(): void {
 	updateVibrancy();
 }
 
-async function setPrivateMode(): Promise<void> {
+function setPrivateMode(): void {
 	document.documentElement.classList.toggle('private-mode', config.get('privateMode'));
 
-	if (is.macos) {
-		if (config.get('privateMode')) {
-			ipc.send('hide-touchbar-labels');
-		} else {
-			const conversationsToRender: Conversation[] = await createConversationList();
-			ipc.send('conversations', conversationsToRender);
-		}
+	if (is.macos && config.get('privateMode')) {
+		ipc.send('hide-touchbar-labels');
 	}
 }
 
@@ -565,7 +560,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 	setDarkMode();
 
 	// Activate Private Mode if it was set before quitting
-	await setPrivateMode();
+	setPrivateMode();
 
 	// Configure do not disturb
 	if (is.macos) {

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -132,7 +132,7 @@ async function createConversation(el: HTMLElement): Promise<Conversation> {
 	return conversation as Conversation;
 }
 
-export async function createConversationList(): Promise<Conversation[]> {
+async function createConversationList(): Promise<Conversation[]> {
 	const list = await elementReady<HTMLElement>(selectors.conversationList, {
 		stopOnDomReady: false
 	});


### PR DESCRIPTION
System: macOS 10.15.2

Conversation -> Insert Emoji & the corresponding chat button would black / white screen the app and make it unusable.
Caprine -> Messenger Preferences... would not open under most* circumstances.

* At certain rare times this function was operational, however I have been unable to reproduce conditions under which it worked.

Fixes #1185