### PR TITLE
Fix badge notification bug when private mode is enabled

### DIFF
--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -1,8 +1,5 @@
 import {ipcRenderer as ipc} from 'electron';
 import elementReady = require('element-ready');
-
-import {is} from 'electron-util';
-import config from '../config';
 import selectors from './selectors';
 
 const icon = {
@@ -152,12 +149,8 @@ export async function createConversationList(): Promise<Conversation[]> {
 }
 
 async function sendConversationList(): Promise<void> {
-	if (is.macos && config.get('privateMode')) {
-		ipc.send('hide-touchbar-labels');
-	} else {
-		const conversationsToRender: Conversation[] = await createConversationList();
-		ipc.send('conversations', conversationsToRender);
-	}
+	const conversationsToRender: Conversation[] = await createConversationList();
+	ipc.send('conversations', conversationsToRender);
 }
 
 window.addEventListener('load', async () => {

--- a/source/touch-bar.ts
+++ b/source/touch-bar.ts
@@ -20,9 +20,18 @@ function setTouchBar(items: Electron.TouchBarButton[]): void {
 	win.setTouchBar(touchBar);
 }
 
+function createLabel(label: string): string {
+	if (label.length > MAX_VISIBLE_LENGTH) {
+		// If the label is too long, we'll render a truncated one with "..." appended
+		return `${label.slice(0, MAX_VISIBLE_LENGTH)}...`;
+	}
+
+	return label;
+}
+
 function createTouchBarButton(label: string, selected: boolean, icon: string, index: number): Electron.TouchBarButton {
 	return new TouchBarButton({
-		label: label.length > MAX_VISIBLE_LENGTH ? label.slice(0, MAX_VISIBLE_LENGTH) + '…' : label,
+		label: createLabel(label),
 		backgroundColor: selected ? '#0084ff' : undefined,
 		icon: nativeImage.createFromDataURL(icon),
 		iconPosition: 'left',

--- a/source/touch-bar.ts
+++ b/source/touch-bar.ts
@@ -1,9 +1,18 @@
 import {TouchBar, ipcMain as ipc, nativeImage, Event as ElectronEvent} from 'electron';
+import {is} from 'electron-util';
+import config from './config';
 import {sendAction, getWindow} from './util';
 import {caprineIconPath} from './constants';
 
 const {TouchBarButton} = TouchBar;
 const MAX_VISIBLE_LENGTH = 25;
+const privateModeTouchBarLabel: Electron.TouchBarButton = new TouchBarButton({
+	label: 'Private mode enabled',
+	backgroundColor: undefined,
+	icon: nativeImage.createFromPath(caprineIconPath),
+	iconPosition: 'left',
+	click: undefined
+});
 
 function setTouchBar(items: Electron.TouchBarButton[]): void {
 	const touchBar = new TouchBar({items});
@@ -11,28 +20,32 @@ function setTouchBar(items: Electron.TouchBarButton[]): void {
 	win.setTouchBar(touchBar);
 }
 
-ipc.on('conversations', (_event: ElectronEvent, conversations: Conversation[]) => {
-	const items = conversations.map(({label, selected, icon}, index: number) => {
-		return new TouchBarButton({
-			label: label.length > MAX_VISIBLE_LENGTH ? label.slice(0, MAX_VISIBLE_LENGTH) + '…' : label,
-			backgroundColor: selected ? '#0084ff' : undefined,
-			icon: nativeImage.createFromDataURL(icon),
-			iconPosition: 'left',
-			click: () => {
-				sendAction('jump-to-conversation', index + 1);
-			}
-		});
+function createTouchBarButton(label: string, selected: boolean, icon: string, index: number): Electron.TouchBarButton {
+	return new TouchBarButton({
+		label: label.length > MAX_VISIBLE_LENGTH ? label.slice(0, MAX_VISIBLE_LENGTH) + '…' : label,
+		backgroundColor: selected ? '#0084ff' : undefined,
+		icon: nativeImage.createFromDataURL(icon),
+		iconPosition: 'left',
+		click: () => {
+			sendAction('jump-to-conversation', index + 1);
+		}
 	});
-	setTouchBar(items);
+}
+
+ipc.on('conversations', (_event: ElectronEvent, conversations: Conversation[]) => {
+	const isPrivateModeEnabled: boolean = is.macos && config.get('privateMode');
+	let touchBarItems: Electron.TouchBarButton[];
+	if (isPrivateModeEnabled) {
+		touchBarItems = [privateModeTouchBarLabel];
+	} else {
+		touchBarItems = conversations.map(({label, selected, icon}, index: number) => {
+			return createTouchBarButton(label, selected, icon, index);
+		});
+	}
+
+	setTouchBar(touchBarItems);
 });
 
 ipc.on('hide-touchbar-labels', (_event: ElectronEvent) => {
-	const privateModeLabel = new TouchBarButton({
-		label: 'Private mode enabled',
-		backgroundColor: undefined,
-		icon: nativeImage.createFromPath(caprineIconPath),
-		iconPosition: 'left',
-		click: undefined
-	});
-	setTouchBar([privateModeLabel]);
+	setTouchBar([privateModeTouchBarLabel]);
 });

--- a/source/touch-bar.ts
+++ b/source/touch-bar.ts
@@ -45,7 +45,3 @@ ipc.on('conversations', (_event: ElectronEvent, conversations: Conversation[]) =
 		setTouchBar(conversations.map(createTouchBarButton));
 	}
 });
-
-ipc.on('hide-touchbar-labels', (_event: ElectronEvent) => {
-	setTouchBar([privateModeTouchBarLabel]);
-});

--- a/source/touch-bar.ts
+++ b/source/touch-bar.ts
@@ -1,5 +1,4 @@
 import {TouchBar, ipcMain as ipc, nativeImage, Event as ElectronEvent} from 'electron';
-import {is} from 'electron-util';
 import config from './config';
 import {sendAction, getWindow} from './util';
 import {caprineIconPath} from './constants';
@@ -8,10 +7,8 @@ const {TouchBarButton} = TouchBar;
 const MAX_VISIBLE_LENGTH = 25;
 const privateModeTouchBarLabel: Electron.TouchBarButton = new TouchBarButton({
 	label: 'Private mode enabled',
-	backgroundColor: undefined,
 	icon: nativeImage.createFromPath(caprineIconPath),
-	iconPosition: 'left',
-	click: undefined
+	iconPosition: 'left'
 });
 
 function setTouchBar(items: Electron.TouchBarButton[]): void {
@@ -22,14 +19,14 @@ function setTouchBar(items: Electron.TouchBarButton[]): void {
 
 function createLabel(label: string): string {
 	if (label.length > MAX_VISIBLE_LENGTH) {
-		// If the label is too long, we'll render a truncated one with "..." appended
-		return `${label.slice(0, MAX_VISIBLE_LENGTH)}...`;
+		// If the label is too long, we'll render a truncated one with "…" appended
+		return `${label.slice(0, MAX_VISIBLE_LENGTH)}…`;
 	}
 
 	return label;
 }
 
-function createTouchBarButton(label: string, selected: boolean, icon: string, index: number): Electron.TouchBarButton {
+function createTouchBarButton({label, selected, icon}: Conversation, index: number): Electron.TouchBarButton {
 	return new TouchBarButton({
 		label: createLabel(label),
 		backgroundColor: selected ? '#0084ff' : undefined,
@@ -42,17 +39,11 @@ function createTouchBarButton(label: string, selected: boolean, icon: string, in
 }
 
 ipc.on('conversations', (_event: ElectronEvent, conversations: Conversation[]) => {
-	const isPrivateModeEnabled: boolean = is.macos && config.get('privateMode');
-	let touchBarItems: Electron.TouchBarButton[];
-	if (isPrivateModeEnabled) {
-		touchBarItems = [privateModeTouchBarLabel];
+	if (config.get('privateMode')) {
+		setTouchBar([privateModeTouchBarLabel]);
 	} else {
-		touchBarItems = conversations.map(({label, selected, icon}, index: number) => {
-			return createTouchBarButton(label, selected, icon, index);
-		});
+		setTouchBar(conversations.map(createTouchBarButton));
 	}
-
-	setTouchBar(touchBarItems);
 });
 
 ipc.on('hide-touchbar-labels', (_event: ElectronEvent) => {


### PR DESCRIPTION
Take a look at https://github.com/sindresorhus/caprine/issues/1257 for more context.

The basic issue was that the **conversations** event was being sent only in cases when private mode was not enabled. This was fine for the majority of cases, but led to a bug in the notification badges not showing up.

This is a proposed fix where I refactored the logic to just always fire the conversations event and just have the Touch Bar component handle the display logic - looking back, this makes much more sense, and I'm embarrassed that I didn't implement this the first time 😅

Thanks @danielfbnunes for pointing this out!

Fixes #1257