### PR TITLE
Use `electron-better-ipc` instead of the built-in IPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"@sindresorhus/do-not-disturb": "^1.1.0",
+		"electron-better-ipc": "^0.8.0",
 		"electron-context-menu": "^0.15.1",
 		"electron-debug": "^3.0.1",
 		"electron-dl": "^1.14.0",

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -1,4 +1,4 @@
-import {ipcRenderer as ipc, Event as ElectronEvent} from 'electron';
+import {ipcRenderer as ipc} from 'electron-better-ipc';
 import {api, is} from 'electron-util';
 import elementReady = require('element-ready');
 import selectors from './browser/selectors';
@@ -76,7 +76,7 @@ function clickBackButton(): void {
 	}
 }
 
-ipc.on('show-preferences', async () => {
+ipc.answerMain('show-preferences', async () => {
 	if (isPreferencesOpen()) {
 		return;
 	}
@@ -84,11 +84,11 @@ ipc.on('show-preferences', async () => {
 	await openPreferences();
 });
 
-ipc.on('new-conversation', () => {
+ipc.answerMain('new-conversation', () => {
 	document.querySelector<HTMLElement>('._30yy[data-href$="/new"]')!.click();
 });
 
-ipc.on('log-out', async () => {
+ipc.answerMain('log-out', async () => {
 	if (config.get('useWorkChat')) {
 		document.querySelector<HTMLElement>('._5lxs._3qct._p')!.click();
 
@@ -111,15 +111,15 @@ ipc.on('log-out', async () => {
 	}
 });
 
-ipc.on('find', () => {
+ipc.answerMain('find', () => {
 	document.querySelector<HTMLElement>('._58al')!.focus();
 });
 
-ipc.on('search', () => {
+ipc.answerMain('search', () => {
 	document.querySelector<HTMLElement>('._3szo:nth-of-type(1)')!.click();
 });
 
-ipc.on('insert-gif', () => {
+ipc.answerMain('insert-gif', () => {
 	const gifElement =
 		// Old UI
 		document.querySelector<HTMLElement>('._yht') ??
@@ -131,7 +131,7 @@ ipc.on('insert-gif', () => {
 	gifElement!.click();
 });
 
-ipc.on('insert-emoji', async () => {
+ipc.answerMain('insert-emoji', async () => {
 	const emojiElement = (await elementReady<HTMLElement>('._5s2p, ._30yy._7odb', {
 		stopOnDomReady: false
 	}))!;
@@ -139,7 +139,7 @@ ipc.on('insert-emoji', async () => {
 	emojiElement.click();
 });
 
-ipc.on('insert-sticker', () => {
+ipc.answerMain('insert-sticker', () => {
 	const stickerElement =
 		// Old UI
 		document.querySelector<HTMLElement>('._4rv6') ??
@@ -151,29 +151,29 @@ ipc.on('insert-sticker', () => {
 	stickerElement!.click();
 });
 
-ipc.on('attach-files', () => {
+ipc.answerMain('attach-files', () => {
 	document
 		.querySelector<HTMLElement>('._5vn8 + input[type="file"], ._7oam input[type="file"]')!
 		.click();
 });
 
-ipc.on('focus-text-input', () => {
+ipc.answerMain('focus-text-input', () => {
 	document.querySelector<HTMLElement>('._7kpg ._5rpu')!.focus();
 });
 
-ipc.on('next-conversation', nextConversation);
+ipc.answerMain('next-conversation', nextConversation);
 
-ipc.on('previous-conversation', previousConversation);
+ipc.answerMain('previous-conversation', previousConversation);
 
-ipc.on('mute-conversation', async () => {
+ipc.answerMain('mute-conversation', async () => {
 	await openMuteModal();
 });
 
-ipc.on('delete-conversation', async () => {
+ipc.answerMain('delete-conversation', async () => {
 	await deleteSelectedConversation();
 });
 
-ipc.on('hide-conversation', async () => {
+ipc.answerMain('hide-conversation', async () => {
 	const index = selectedConversationIndex();
 
 	if (index !== -1) {
@@ -202,9 +202,9 @@ async function openHiddenPreferences(): Promise<boolean> {
 	return false;
 }
 
-ipc.on(
+ipc.answerMain(
 	'toggle-sounds',
-	async (_event: ElectronEvent, checked: boolean): Promise<void> => {
+	async (checked: boolean): Promise<void> => {
 		const shouldClosePreferences = await openHiddenPreferences();
 
 		const soundsCheckbox = document.querySelector<HTMLInputElement>(messengerSoundsSelector)!;
@@ -218,7 +218,7 @@ ipc.on(
 	}
 );
 
-ipc.on('toggle-mute-notifications', async (_event: ElectronEvent, defaultStatus: boolean) => {
+ipc.answerMain('toggle-mute-notifications', async (defaultStatus: boolean) => {
 	const shouldClosePreferences = await openHiddenPreferences();
 
 	const notificationCheckbox = document.querySelector<HTMLInputElement>(
@@ -234,34 +234,34 @@ ipc.on('toggle-mute-notifications', async (_event: ElectronEvent, defaultStatus:
 		notificationCheckbox.click();
 	}
 
-	ipc.send('mute-notifications-toggled', !notificationCheckbox.checked);
+	ipc.callMain('mute-notifications-toggled', !notificationCheckbox.checked);
 
 	if (shouldClosePreferences) {
 		closePreferences();
 	}
 });
 
-ipc.on('toggle-message-buttons', () => {
+ipc.answerMain('toggle-message-buttons', () => {
 	document.body.classList.toggle('show-message-buttons', config.get('showMessageButtons'));
 });
 
-ipc.on('show-active-contacts-view', async () => {
+ipc.answerMain('show-active-contacts-view', async () => {
 	await selectOtherListViews(3);
 });
 
-ipc.on('show-message-requests-view', async () => {
+ipc.answerMain('show-message-requests-view', async () => {
 	await selectOtherListViews(4);
 });
 
-ipc.on('show-hidden-threads-view', async () => {
+ipc.answerMain('show-hidden-threads-view', async () => {
 	await selectOtherListViews(5);
 });
 
-ipc.on('toggle-unread-threads-view', async () => {
+ipc.answerMain('toggle-unread-threads-view', async () => {
 	await selectOtherListViews(6);
 });
 
-ipc.on('toggle-video-autoplay', () => {
+ipc.answerMain('toggle-video-autoplay', () => {
 	toggleVideoAutoplay();
 });
 
@@ -281,10 +281,10 @@ async function setPrivateMode(): Promise<void> {
 
 	if (is.macos) {
 		if (config.get('privateMode')) {
-			ipc.send('hide-touchbar-labels');
+			ipc.callMain('hide-touchbar-labels');
 		} else {
 			const conversationsToRender: Conversation[] = await createConversationList();
-			ipc.send('conversations', conversationsToRender);
+			ipc.callMain('conversations', conversationsToRender);
 		}
 	}
 }
@@ -304,7 +304,7 @@ function updateVibrancy(): void {
 		default:
 	}
 
-	ipc.send('set-vibrancy');
+	ipc.callMain('set-vibrancy');
 }
 
 function updateSidebar(): void {
@@ -325,7 +325,7 @@ function updateSidebar(): void {
 		default:
 	}
 
-	ipc.send('set-sidebar');
+	ipc.callMain('set-sidebar');
 }
 
 async function updateDoNotDisturb(): Promise<void> {
@@ -336,7 +336,7 @@ async function updateDoNotDisturb(): Promise<void> {
 		closePreferences();
 	}
 
-	ipc.send('update-dnd-mode', soundsCheckbox.checked);
+	ipc.callMain('update-dnd-mode', soundsCheckbox.checked);
 }
 
 function renderOverlayIcon(messageCount: number): HTMLCanvasElement {
@@ -358,27 +358,28 @@ function renderOverlayIcon(messageCount: number): HTMLCanvasElement {
 	return canvas;
 }
 
-ipc.on('update-sidebar', () => {
+ipc.answerMain('update-sidebar', () => {
 	updateSidebar();
 });
 
-ipc.on('set-dark-mode', setDarkMode);
+ipc.answerMain('set-dark-mode', setDarkMode);
 
-ipc.on('set-private-mode', setPrivateMode);
+ipc.answerMain('set-private-mode', setPrivateMode);
 
-ipc.on('update-vibrancy', () => {
+ipc.answerMain('update-vibrancy', () => {
 	updateVibrancy();
 });
 
-ipc.on('render-overlay-icon', (_event: ElectronEvent, messageCount: number) => {
-	ipc.send(
-		'update-overlay-icon',
-		renderOverlayIcon(messageCount).toDataURL(),
-		String(messageCount)
+ipc.answerMain('render-overlay-icon', (messageCount: number) => {
+	ipc.callMain(
+		'update-overlay-icon', {
+			data: renderOverlayIcon(messageCount).toDataURL(),
+			text: String(messageCount)
+		}
 	);
 });
 
-ipc.on('render-native-emoji', (_event: ElectronEvent, emoji: string) => {
+ipc.answerMain('render-native-emoji', (emoji: string) => {
 	const canvas = document.createElement('canvas');
 	const context = canvas.getContext('2d')!;
 	canvas.width = 256;
@@ -395,14 +396,14 @@ ipc.on('render-native-emoji', (_event: ElectronEvent, emoji: string) => {
 	}
 
 	const dataUrl = canvas.toDataURL();
-	ipc.send('native-emoji', {emoji, dataUrl});
+	ipc.callMain('native-emoji', {emoji, dataUrl});
 });
 
-ipc.on('zoom-reset', () => {
+ipc.answerMain('zoom-reset', () => {
 	setZoom(1);
 });
 
-ipc.on('zoom-in', () => {
+ipc.answerMain('zoom-in', () => {
 	const zoomFactor = config.get('zoomFactor') + 0.1;
 
 	if (zoomFactor < 1.6) {
@@ -410,7 +411,7 @@ ipc.on('zoom-in', () => {
 	}
 });
 
-ipc.on('zoom-out', () => {
+ipc.answerMain('zoom-out', () => {
 	const zoomFactor = config.get('zoomFactor') - 0.1;
 
 	if (zoomFactor >= 0.8) {
@@ -418,7 +419,7 @@ ipc.on('zoom-out', () => {
 	}
 });
 
-ipc.on('jump-to-conversation', async (_event: ElectronEvent, key: number) => {
+ipc.answerMain('jump-to-conversation', async (key: number) => {
 	await jumpToConversation(key);
 });
 
@@ -575,7 +576,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 	// Prevent flash of white on startup when in dark mode
 	// TODO: find a CSS-only solution
 	if (!is.macos && config.get('darkMode')) {
-		// eslint-disable-next-line require-atomic-updates
 		document.documentElement.style.backgroundColor = '#1e1e1e';
 	}
 
@@ -655,7 +655,7 @@ function showNotification({id, title, body, icon, silent}: NotificationEvent): v
 
 		context.drawImage(image, 0, 0, image.width, image.height);
 
-		ipc.send('notification', {
+		ipc.callMain('notification', {
 			id,
 			title,
 			body,
@@ -703,11 +703,11 @@ function insertMessageText(text: string, inputField: HTMLElement): void {
 	document.execCommand('insertText', false, text);
 }
 
-ipc.on('notification-callback', (_event: ElectronEvent, data: unknown) => {
+ipc.answerMain('notification-callback', (data: unknown) => {
 	window.postMessage({type: 'notification-callback', data}, '*');
 });
 
-ipc.on('notification-reply-callback', (_event: ElectronEvent, data: any) => {
+ipc.answerMain('notification-reply-callback', (data: any) => {
 	const previousConversation = selectedConversationIndex();
 	data.previousConversation = previousConversation;
 	window.postMessage({type: 'notification-reply-callback', data}, '*');

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -376,7 +376,7 @@ ipc.answerMain('render-overlay-icon', (messageCount: number): {data: string; tex
 	};
 });
 
-ipc.answerMain('render-native-emoji', (emoji: string): {emoji: string; dataUrl: string} => {
+ipc.answerMain('render-native-emoji', (emoji: string): string => {
 	const canvas = document.createElement('canvas');
 	const context = canvas.getContext('2d')!;
 	canvas.width = 256;
@@ -393,7 +393,7 @@ ipc.answerMain('render-native-emoji', (emoji: string): {emoji: string; dataUrl: 
 	}
 
 	const dataUrl = canvas.toDataURL();
-	return {emoji, dataUrl};
+	return dataUrl;
 });
 
 ipc.answerMain('zoom-reset', () => {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -573,6 +573,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 	// Prevent flash of white on startup when in dark mode
 	// TODO: find a CSS-only solution
 	if (!is.macos && config.get('darkMode')) {
+		// eslint-disable-next-line require-atomic-updates
 		document.documentElement.style.backgroundColor = '#1e1e1e';
 	}
 

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -1,4 +1,4 @@
-import {ipcRenderer as ipc} from 'electron';
+import {ipcRenderer as ipc} from 'electron-better-ipc';
 import elementReady = require('element-ready');
 
 import {is} from 'electron-util';
@@ -153,10 +153,10 @@ export async function createConversationList(): Promise<Conversation[]> {
 
 async function sendConversationList(): Promise<void> {
 	if (is.macos && config.get('privateMode')) {
-		ipc.send('hide-touchbar-labels');
+		ipc.callMain('hide-touchbar-labels');
 	} else {
 		const conversationsToRender: Conversation[] = await createConversationList();
-		ipc.send('conversations', conversationsToRender);
+		ipc.callMain('conversations', conversationsToRender);
 	}
 }
 

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -4,10 +4,9 @@ import {
 	NativeImage,
 	MenuItemConstructorOptions,
 	Response,
-	ipcMain,
-	Event as ElectronEvent,
 	Menu
 } from 'electron';
+import {ipcMain} from 'electron-better-ipc';
 import {memoize} from 'lodash';
 import config from './config';
 import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
@@ -236,7 +235,7 @@ Renders the given emoji in the renderer process and returns a PNG `data:` URL.
 const renderEmoji = memoize(
 	async (emoji: string): Promise<string> =>
 		new Promise(resolve => {
-			const listener = (_event: ElectronEvent, arg: {emoji: string; dataUrl: string}): void => {
+			const listener = (arg: {emoji: string; dataUrl: string}): void => {
 				if (arg.emoji !== emoji) {
 					return;
 				}
@@ -245,7 +244,7 @@ const renderEmoji = memoize(
 				resolve(arg.dataUrl);
 			};
 
-			ipcMain.on('native-emoji', listener);
+			ipcMain.answerRenderer('native-emoji', listener);
 			sendBackgroundAction('render-native-emoji', emoji);
 		})
 );

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -6,7 +6,6 @@ import {
 	Response,
 	Menu
 } from 'electron';
-import {ipcMain} from 'electron-better-ipc';
 import {memoize} from 'lodash';
 import config from './config';
 import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
@@ -232,22 +231,7 @@ function codeForEmojiStyle(style: EmojiStyle): EmojiStyleCode {
 /**
 Renders the given emoji in the renderer process and returns a PNG `data:` URL.
 */
-const renderEmoji = memoize(
-	async (emoji: string): Promise<string> =>
-		new Promise(async resolve => {
-			const listener = (arg: {emoji: string; dataUrl: string}): void => {
-				if (arg.emoji !== emoji) {
-					return;
-				}
-
-				ipcMain.removeListener('native-emoji', listener);
-				resolve(arg.dataUrl);
-			};
-
-			ipcMain.answerRenderer('native-emoji', listener);
-			listener(await sendBackgroundAction('render-native-emoji', emoji));
-		})
-);
+const renderEmoji = memoize(async (emoji: string): Promise<string> => sendBackgroundAction<string, string>('render-native-emoji', emoji));
 
 /**
 @param url - A Facebook emoji URL like `https://static.xx.fbcdn.net/images/emoji.php/v9/tae/2/16/1f471_1f3fb_200d_2640.png`.

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -234,7 +234,7 @@ Renders the given emoji in the renderer process and returns a PNG `data:` URL.
 */
 const renderEmoji = memoize(
 	async (emoji: string): Promise<string> =>
-		new Promise(resolve => {
+		new Promise(async resolve => {
 			const listener = (arg: {emoji: string; dataUrl: string}): void => {
 				if (arg.emoji !== emoji) {
 					return;
@@ -245,7 +245,7 @@ const renderEmoji = memoize(
 			};
 
 			ipcMain.answerRenderer('native-emoji', listener);
-			sendBackgroundAction('render-native-emoji', emoji);
+			listener(await sendBackgroundAction('render-native-emoji', emoji));
 		})
 );
 

--- a/source/touch-bar.ts
+++ b/source/touch-bar.ts
@@ -1,4 +1,5 @@
-import {TouchBar, ipcMain as ipc, nativeImage, Event as ElectronEvent} from 'electron';
+import {TouchBar, nativeImage} from 'electron';
+import {ipcMain as ipc} from 'electron-better-ipc';
 import {sendAction, getWindow} from './util';
 import {caprineIconPath} from './constants';
 
@@ -11,7 +12,7 @@ function setTouchBar(items: Electron.TouchBarButton[]): void {
 	win.setTouchBar(touchBar);
 }
 
-ipc.on('conversations', (_event: ElectronEvent, conversations: Conversation[]) => {
+ipc.answerRenderer('conversations', (conversations: Conversation[]) => {
 	const items = conversations.map(({label, selected, icon}, index: number) => {
 		return new TouchBarButton({
 			label: label.length > MAX_VISIBLE_LENGTH ? label.slice(0, MAX_VISIBLE_LENGTH) + '…' : label,
@@ -26,7 +27,7 @@ ipc.on('conversations', (_event: ElectronEvent, conversations: Conversation[]) =
 	setTouchBar(items);
 });
 
-ipc.on('hide-touchbar-labels', (_event: ElectronEvent) => {
+ipc.answerRenderer('hide-touchbar-labels', () => {
 	const privateModeLabel = new TouchBarButton({
 		label: 'Private mode enabled',
 		backgroundColor: undefined,

--- a/source/util.ts
+++ b/source/util.ts
@@ -18,8 +18,8 @@ export function sendAction<T>(action: string, args?: T): void {
 	ipcMain.callRenderer(win, action, args);
 }
 
-export function sendBackgroundAction<T>(action: string, args?: T): void {
-	ipcMain.callRenderer(getWindow(), action, args);
+export async function sendBackgroundAction<T, TReturn>(action: string, args?: T): Promise<TReturn> {
+	return ipcMain.callRenderer<T, TReturn>(getWindow(), action, args);
 }
 
 export function showRestartDialog(message: string): void {

--- a/source/util.ts
+++ b/source/util.ts
@@ -1,4 +1,5 @@
 import {app, BrowserWindow, dialog} from 'electron';
+import {ipcMain} from 'electron-better-ipc';
 import {is} from 'electron-util';
 import config from './config';
 
@@ -7,18 +8,18 @@ export function getWindow(): BrowserWindow {
 	return win;
 }
 
-export function sendAction(action: string, ...args: unknown[]): void {
+export function sendAction<T>(action: string, args?: T): void {
 	const win = getWindow();
 
 	if (is.macos) {
 		win.restore();
 	}
 
-	win.webContents.send(action, ...args);
+	ipcMain.callRenderer(win, action, args);
 }
 
-export function sendBackgroundAction(action: string, ...args: unknown[]): void {
-	getWindow().webContents.send(action, ...args);
+export function sendBackgroundAction<T>(action: string, args?: T): void {
+	ipcMain.callRenderer(getWindow(), action, args);
 }
 
 export function showRestartDialog(message: string): void {


### PR DESCRIPTION
As @sindresorhus mentioned in an issue https://github.com/sindresorhus/caprine/issues/848, Caprine should use [`electron-better-ipc`](https://github.com/sindresorhus/electron-better-ipc) so code would be more simple and readable.

Not a lot of code was removed but some unnecessary event listeners were removed because of `electron-better-ipc` features for sending and receiving data in a single emit.

An important thing to check would be the refactoring of the [`renderEmoji()`](https://github.com/sindresorhus/caprine/compare/master...dusansimic:add-electron-better-ipc?expand=1#diff-42884126f5a9ea114868102427dd7a72R234) function in `emoji.ts`. A lot of code is removed there since all the checks done by that function are actually implemented in `electron-better-ipc`. By that I mean that the if statement used to check if the correct emoji is received as a response because electron ipc doesn't handle unique requests on the same channel but rather all the response events are handled by the first listener that catches them, is no longer needed since `electron-better-ipc` handles that problem with ids for each ipc call.

I'd like to thank @felixfbecker who helped me out with the `renderEmoji()` refactoring by explaining the behavior of generic ipc.

Closes: https://github.com/sindresorhus/caprine/issues/848