### PR TITLE
Add remember option checkbox in private mode dialog

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -5,6 +5,7 @@ type StoreType = {
 	followSystemAppearance: boolean;
 	darkMode: boolean;
 	privateMode: boolean;
+	showPrivateModeModal: boolean;
 	vibrancy: 'none' | 'sidebar' | 'full';
 	zoomFactor: number;
 	lastWindowState: {
@@ -51,6 +52,10 @@ const schema: {[Key in keyof StoreType]: Store.Schema} = {
 	privateMode: {
 		type: 'boolean',
 		default: false
+	},
+	showPrivateModeModal: {
+		type: 'boolean',
+		default: true
 	},
 	vibrancy: {
 		type: 'string',

--- a/source/config.ts
+++ b/source/config.ts
@@ -5,7 +5,7 @@ type StoreType = {
 	followSystemAppearance: boolean;
 	darkMode: boolean;
 	privateMode: boolean;
-	showPrivateModeModal: boolean;
+	showPrivateModePrompt: boolean;
 	vibrancy: 'none' | 'sidebar' | 'full';
 	zoomFactor: number;
 	lastWindowState: {
@@ -53,7 +53,7 @@ const schema: {[Key in keyof StoreType]: Store.Schema} = {
 		type: 'boolean',
 		default: false
 	},
-	showPrivateModeModal: {
+	showPrivateModePrompt: {
 		type: 'boolean',
 		default: true
 	},

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -425,8 +425,8 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			checked: config.get('privateMode'),
 			accelerator: 'CommandOrControl+Shift+N',
 			async click(menuItem, _browserWindow, event) {
-				if (!config.get('privateMode') && config.get('showPrivateModeModal') && event.shiftKey) {
-					await dialog.showMessageBox(_browserWindow, {
+				if (!config.get('privateMode') && config.get('showPrivateModePrompt') && event.shiftKey) {
+					const result = await dialog.showMessageBox(_browserWindow, {
 						message: 'Are you sure you want to hide names and avatars?',
 						detail: 'This was triggered by Command/Control+Shift+N.',
 						buttons: [
@@ -436,15 +436,14 @@ Press Command/Ctrl+R in Caprine to see your changes.
 						defaultId: 0,
 						cancelId: 1,
 						checkboxLabel: 'Don\'t ask me again'
-					}).then(res => {
-						config.set('showPrivateModeModal', !res.checkboxChecked);
-						if (res.response === 0) {
-							config.set('privateMode', !config.get('privateMode'));
-							sendAction('set-private-mode');
-						} else if (res.response === 1) {
-							menuItem.checked = false;
-						}
 					});
+					config.set('showPrivateModePrompt', !result.checkboxChecked);
+					if (result.response === 0) {
+						config.set('privateMode', !config.get('privateMode'));
+						sendAction('set-private-mode');
+					} else if (result.response === 1) {
+						menuItem.checked = false;
+					}
 				} else {
 					config.set('privateMode', !config.get('privateMode'));
 					sendAction('set-private-mode');

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -437,7 +437,9 @@ Press Command/Ctrl+R in Caprine to see your changes.
 						cancelId: 1,
 						checkboxLabel: 'Don\'t ask me again'
 					});
+
 					config.set('showPrivateModePrompt', !result.checkboxChecked);
+
 					if (result.response === 0) {
 						config.set('privateMode', !config.get('privateMode'));
 						sendAction('set-private-mode');

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -424,9 +424,9 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			type: 'checkbox',
 			checked: config.get('privateMode'),
 			accelerator: 'CommandOrControl+Shift+N',
-			click(menuItem, _browserWindow, event) {
-				if (!config.get('privateMode') && event.shiftKey) {
-					const confirmPrivateMode = dialog.showMessageBoxSync({
+			async click(menuItem, _browserWindow, event) {
+				if (!config.get('privateMode') && config.get('showPrivateModeModal') && event.shiftKey) {
+					await dialog.showMessageBox(_browserWindow, {
 						message: 'Are you sure you want to hide names and avatars?',
 						detail: 'This was triggered by Command/Control+Shift+N.',
 						buttons: [
@@ -434,17 +434,21 @@ Press Command/Ctrl+R in Caprine to see your changes.
 							'Don\'t Hide'
 						],
 						defaultId: 0,
-						cancelId: 1
-					}) === 0;
-
-					if (!confirmPrivateMode) {
-						menuItem.checked = false;
-						return;
-					}
+						cancelId: 1,
+						checkboxLabel: 'Don\'t ask me again'
+					}).then(res => {
+						config.set('showPrivateModeModal', !res.checkboxChecked);
+						if (res.response === 0) {
+							config.set('privateMode', !config.get('privateMode'));
+							sendAction('set-private-mode');
+						} else if (res.response === 1) {
+							menuItem.checked = false;
+						}
+					});
+				} else {
+					config.set('privateMode', !config.get('privateMode'));
+					sendAction('set-private-mode');
 				}
-
-				config.set('privateMode', !config.get('privateMode'));
-				sendAction('set-private-mode');
 			}
 		},
 		{


### PR DESCRIPTION
Resolves #1186 

I have already looked at this problem before but Electron had a bug with the checkbox. electron/electron#21159

I had to use async function because sync doesn't return information if the check was checked or not.
Also when you once check the check you have to 'Debug->Delete settings' if you want to see dialog again.