### PR TITLE
Fix the sidebar config migration

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -319,8 +319,6 @@ function updateSidebar(): void {
 			break;
 		default:
 	}
-
-	ipc.callMain('set-sidebar');
 }
 
 async function updateDoNotDisturb(): Promise<void> {

--- a/source/config.ts
+++ b/source/config.ts
@@ -214,7 +214,8 @@ function updateVibrancySetting(store: Store): void {
 function updateSidebarSetting(store: Store): void {
 	if (store.get('sidebarHidden')) {
 		store.set('sidebar', 'hidden');
-	} else {
+		store.delete('sidebarHidden');
+	} else if (!store.has('sidebar')) {
 		store.set('sidebar', 'default');
 	}
 }


### PR DESCRIPTION
Fixes #1305

Summary:

- The issue was that the config would always be overwritten for those who didn't have the `sidebarHidden` key to always `default`.
- After setting the new migration key, we should also delete the old one so we don't reset it to `hidden` every time.
- I've also deleted a IPC call that looks out of place.

cc @sindresorhus @CvX 