### PR TITLE
Fix making and receiving calls

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -307,6 +307,7 @@ function createMainWindow(): BrowserWindow {
 		darkTheme: isDarkMode, // GTK+3
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
+			nativeWindowOpen: true,
 			contextIsolation: true,
 			plugins: true
 		}
@@ -510,7 +511,7 @@ function createMainWindow(): BrowserWindow {
 	webContents.on('new-window', async (event: Event, url, frameName, _disposition, options) => {
 		event.preventDefault();
 
-		if (url === 'about:blank') {
+		if (url === 'about:blank' || url === 'about:blank#blocked') {
 			if (frameName !== 'about:blank') {
 				// Voice/video call popup
 				options.show = true;
@@ -519,7 +520,6 @@ function createMainWindow(): BrowserWindow {
 				options.webPreferences.nodeIntegration = false;
 				options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
 				(event as any).newGuest = new BrowserWindow(options);
-				(event as any).newGuest.loadURL('https://www.messenger.com');
 			}
 		} else {
 			url = stripTrackingFromUrl(url);

--- a/source/index.ts
+++ b/source/index.ts
@@ -519,6 +519,7 @@ function createMainWindow(): BrowserWindow {
 				options.webPreferences.nodeIntegration = false;
 				options.webPreferences.preload = path.join(__dirname, 'browser-call.js');
 				(event as any).newGuest = new BrowserWindow(options);
+				(event as any).newGuest.loadURL('https://www.messenger.com');
 			}
 		} else {
 			url = stripTrackingFromUrl(url);


### PR DESCRIPTION
Workaround electron's location handling on new windows [window.open()]

Fixes #1189

I also described the full solution in my [comment](https://github.com/sindresorhus/caprine/issues/1189#issuecomment-609765491) on the issue. 

> - Doing newWindow.location = "/path" fails because at it seems, by default electron is trying to join the new-window's location (that window's window.location) with the new location (/path), but the new-window doesn't have valid location.href because it wasn't opened with one.
>     `w1 = window.open() // w1.location.href === "about:blank"`
>     In normal browser, as long as your new location is not valid URL on it's own (?) it would join the new path with current's window (the window from where you are opening the new-window) location, not the new-window's one.
> 
> **Solution**
> 
> - When open of Group Calls window is detected, additionally pre-set the location to `https://www.messenger.com`.
> 
