### PR TITLE
Fix unread badge not always updating

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -265,6 +265,10 @@ ipc.answerMain('toggle-video-autoplay', () => {
 	toggleVideoAutoplay();
 });
 
+ipc.answerMain('reload', () => {
+	location.reload();
+})
+
 function setDarkMode(): void {
 	if (is.macos && config.get('followSystemAppearance')) {
 		api.nativeTheme.themeSource = 'system';

--- a/source/index.ts
+++ b/source/index.ts
@@ -142,13 +142,11 @@ async function updateBadge(conversations: Conversation[]): Promise<void> {
 	tray.update(messageCount);
 
 	if (is.windows) {
-		if (config.get('showUnreadBadge')) {
-			if (messageCount === 0) {
-				mainWindow.setOverlayIcon(null, '');
-			} else {
-				// Delegate drawing of overlay icon to renderer process
-				updateOverlayIcon(await ipcMain.callRenderer(mainWindow, 'render-overlay-icon', messageCount));
-			}
+		if (!config.get('showUnreadBadge') || messageCount === 0) {
+			mainWindow.setOverlayIcon(null, '');
+		} else {
+			// Delegate drawing of overlay icon to renderer process
+			updateOverlayIcon(await ipcMain.callRenderer(mainWindow, 'render-overlay-icon', messageCount));
 		}
 	}
 }

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -262,6 +262,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			checked: config.get('showUnreadBadge'),
 			click() {
 				config.set('showUnreadBadge', !config.get('showUnreadBadge'));
+				sendAction('reload');
 			}
 		},
 		{


### PR DESCRIPTION
If the show unread badge option is toggled then sends a reload action to browser to refresh badge fixes #1355 . Also updates index.ts updateBadge to remove the badge overlay icon if config.get('showUnreadBadge') is false.