### PR TITLE
Add option to disable spell checker

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -40,6 +40,7 @@ type StoreType = {
 	quitOnWindowClose: boolean;
 	keepMeSignedIn: boolean;
 	autoplayVideos: boolean;
+	enableSpellChecker: boolean;
 	spellCheckerLanguages: string[];
 };
 
@@ -195,6 +196,10 @@ const schema: {[Key in keyof StoreType]: Store.Schema} = {
 		default: true
 	},
 	autoplayVideos: {
+		type: 'boolean',
+		default: true
+	},
+	enableSpellChecker: {
 		type: 'boolean',
 		default: true
 	},

--- a/source/config.ts
+++ b/source/config.ts
@@ -40,7 +40,7 @@ type StoreType = {
 	quitOnWindowClose: boolean;
 	keepMeSignedIn: boolean;
 	autoplayVideos: boolean;
-	enableSpellChecker: boolean;
+	isSpellCheckerEnabled: boolean;
 	spellCheckerLanguages: string[];
 };
 
@@ -199,7 +199,7 @@ const schema: {[Key in keyof StoreType]: Store.Schema} = {
 		type: 'boolean',
 		default: true
 	},
-	enableSpellChecker: {
+	isSpellCheckerEnabled: {
 		type: 'boolean',
 		default: true
 	},

--- a/source/index.ts
+++ b/source/index.ts
@@ -309,7 +309,7 @@ function createMainWindow(): BrowserWindow {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,
 			contextIsolation: true,
-			spellcheck: true,
+			spellcheck: config.get('enableSpellChecker'),
 			plugins: true
 		}
 	});

--- a/source/index.ts
+++ b/source/index.ts
@@ -309,7 +309,7 @@ function createMainWindow(): BrowserWindow {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,
 			contextIsolation: true,
-			spellcheck: config.get('enableSpellChecker'),
+			spellcheck: config.get('isSpellCheckerEnabled'),
 			plugins: true
 		}
 	});

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -265,6 +265,15 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			label: 'Enable Spell Checker',
+			type: 'checkbox',
+			checked: config.get('enableSpellChecker'),
+			click() {
+				config.set('enableSpellChecker', !config.get('enableSpellChecker'));
+				showRestartDialog('Caprine needs to be restarted to enable or disable the spell checker.');
+			}
+		},
+		{
 			label: 'Hardware Acceleration',
 			type: 'checkbox',
 			checked: config.get('hardwareAcceleration'),
@@ -607,7 +616,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 		},
 		{
 			label: 'Spell Checker Language',
-			visible: !is.macos,
+			visible: !is.macos && config.get('enableSpellChecker'),
 			submenu: spellCheckerSubmenu
 		}
 	];

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -265,11 +265,11 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
-			label: 'Enable Spell Checker',
+			label: 'Spell Checker',
 			type: 'checkbox',
-			checked: config.get('enableSpellChecker'),
+			checked: config.get('isSpellCheckerEnabled'),
 			click() {
-				config.set('enableSpellChecker', !config.get('enableSpellChecker'));
+				config.set('isSpellCheckerEnabled', !config.get('isSpellCheckerEnabled'));
 				showRestartDialog('Caprine needs to be restarted to enable or disable the spell checker.');
 			}
 		},
@@ -616,7 +616,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 		},
 		{
 			label: 'Spell Checker Language',
-			visible: !is.macos && config.get('enableSpellChecker'),
+			visible: !is.macos && config.get('isSpellCheckerEnabled'),
 			submenu: spellCheckerSubmenu
 		}
 	];


### PR DESCRIPTION
The spell checker can be quite annoying at times, so I've added an option to Caprine's preferences to configure whether it is enabled.
I couldn't find a good way to update the BrowserWindow webPreferences option during runtime, so unfortunately a restart is needed to configure the spell checker.