### PR TITLE
Fix autoscroll on new messages

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -548,12 +548,25 @@ async function observeAutoscroll(): Promise<void> {
 		return;
 	}
 
+	const scrollToBottom = (): void => {
+		const scrollableElement: HTMLElement | null = document.querySelector('[role=presentation] .scrollable');
+		if (scrollableElement) {
+			scrollableElement.scroll({
+				top: Number.MAX_SAFE_INTEGER,
+				behavior: 'smooth'
+			});
+		}
+	}
+
 	const hookMessageObserver = async (): Promise<void> => {
 		const chatElement = await elementReady<HTMLElement>(
 			'[role=presentation] .scrollable [role = region] > div[id ^= "js_"]', {stopOnDomReady: false}
 		);
 
 		if (chatElement) {
+			// Scroll to the bottom when opening different conversation
+			scrollToBottom();
+
 			const messageObserver = new MutationObserver((record: MutationRecord[]) => {
 				const newMessages: MutationRecord[] = record.filter(record => {
 					// The mutation is an addition
@@ -565,13 +578,8 @@ async function observeAutoscroll(): Promise<void> {
 				});
 
 				if (newMessages.length > 0) {
-					const scrollableElement: HTMLElement | null = document.querySelector('[role=presentation] .scrollable');
-					if (scrollableElement) {
-						scrollableElement.scroll({
-							top: Number.MAX_SAFE_INTEGER,
-							behavior: 'smooth'
-						});
-					}
+					// Scroll to the bottom when there are new messages
+					scrollToBottom();
 				}
 			});
 

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -554,14 +554,14 @@ async function observeAutoscroll(): Promise<void> {
 		);
 
 		if (chatElement) {
-			const messageObserver = new MutationObserver((r: MutationRecord[]) => {
-				const newMessages: MutationRecord[] = r.filter(r => {
+			const messageObserver = new MutationObserver((record: MutationRecord[]) => {
+				const newMessages: MutationRecord[] = record.filter(record => {
 					// The mutation is an addition
-					return r.addedNodes.length > 0 &&
+					return record.addedNodes.length > 0 &&
 						// ... of a div       (skip the "seen" status change)
-						(r.addedNodes[0] as HTMLElement).tagName === 'DIV' &&
+						(record.addedNodes[0] as HTMLElement).tagName === 'DIV' &&
 						// ... on the last child       (skip previous messages added when scrolling up)
-						chatElement.lastChild!.contains(r.target);
+						chatElement.lastChild!.contains(record.target);
 				});
 
 				if (newMessages.length > 0) {


### PR DESCRIPTION
This completes the requested changes in https://github.com/sindresorhus/caprine/pull/1295. It's basically the same PR and most of the code is from @fbianconi. I've made this since there hasn't been a lot of activity on this issue for some time and I wanted to get it fixed.

 - [x] Fix variable names
 - [x] Scroll on conversation change

Closes: https://github.com/sindresorhus/caprine/issues/1278