### PR TITLE
Fix 2FA login issue

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -529,7 +529,7 @@ function createMainWindow(): BrowserWindow {
 		};
 
 		const isTwoFactorAuth = (url: string): boolean => {
-			const twoFactorAuthURL = 'https://www.facebook.com/checkpoint/start';
+			const twoFactorAuthURL = 'https://www.facebook.com/checkpoint';
 			return url.startsWith(twoFactorAuthURL);
 		};
 


### PR DESCRIPTION
FB changed their 2FA login url. Without this change, Electron will open the 2FA login page using external browser.

Fixes #1415
Fixes #1414