### PR TITLE
Fix dark mode

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -436,6 +436,11 @@ html.dark-mode ._7hty {
 	filter: invert(1) !important;
 }
 
+/* Right sidebar: theme icon color */
+html.dark-mode ._6ymf {
+	background-color: var(--container-color);
+}
+
 /* Right sidebar: mute notification label */
 html.dark-mode ._3szq {
 	color: var(--base-seventy);

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -204,6 +204,11 @@ html.dark-mode ._7-_v svg path {
 	fill: var(--base-seventy-five);
 }
 
+/* Message list: forwarded photo label */
+html.dark-mode ._879m {
+	color: var(--base-fifty);
+}
+
 /* Messages list: Poll color (title) */
 html.dark-mode ._3b4u {
 	color: var(--base-seventy);


### PR DESCRIPTION
Minor dark mode style fixes:

- [x] Label color above forwarded image (it used to be black)
- [x] Color of inner circle for chat color (it used to be white)

Closes: #1155 