### PR TITLE
Fix scroll bar in message box

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -35,11 +35,6 @@ body {
 	-webkit-app-region: drag;
 }
 
-/* Fix broken scroll arrows on message input on Windows */
-._kmc {
-	overflow-y: hidden !important;
-}
-
 /* Exclude `New Messages`, `Voice Call`, `Video Call` & `Conversation Info` buttons from the draggable region */
 ._36ic._5l-3 ._30yy,
 ._5742 ._30yy,


### PR DESCRIPTION
Scroll bar was being hidden due to an old bug on Windows. This would make it hard to scroll in the message box of there was a lot of text.

Closes: #1223