### PR TITLE
Fix Windows icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
 			"publish": "github"
 		},
 		"win": {
-			"verifyUpdateCodeSignature": false
+			"verifyUpdateCodeSignature": false,
+			"icon": "build/icon.png"
 		}
 	},
 	"husky": {


### PR DESCRIPTION
Add fix for Windows app icon. This fixes the icon being cut in half and bad resolution of the icon. The solution for this issue was found here https://github.com/electron-userland/electron-builder/issues/2128.

Closes: #1429 
Closes: #1453 