### PR TITLE
Fix dark mode on new Messenger UI

### DIFF
--- a/css/new-design/dark-mode.css
+++ b/css/new-design/dark-mode.css
@@ -1,0 +1,35 @@
+/* Top bar: App menu button color */
+[aria-label="Settings, help and more"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}
+
+/* Top bar: New message button color */
+[aria-label="New Message"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}
+
+/* Preferences: Icon color */
+[aria-label="Preferences"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}
+
+/* Menu: Icon color in menu */
+[role="menu"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}
+
+/* Right sidebar: Icon color */
+.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.g5gj957u.f4tghd1a.ifue306u.kuivcneq.t63ysoy8 .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}
+
+/* Contact list: delivered icon color */
+.aahdfvyu [role="grid"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -277,6 +277,8 @@ function setDarkMode(): void {
 	}
 
 	document.documentElement.classList.toggle('dark-mode', api.nativeTheme.shouldUseDarkColors);
+	document.documentElement.classList.toggle('__fb-dark-mode', api.nativeTheme.shouldUseDarkColors);
+
 	updateVibrancy();
 }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -447,7 +447,6 @@ function createMainWindow(): BrowserWindow {
 		const files = ['browser.css', 'dark-mode.css', 'vibrancy.css', 'code-blocks.css', 'autoplay.css'];
 
 		const isNewDesign = await ipcMain.callRenderer<undefined, Element>(mainWindow, 'check-new-ui');
-		console.log(isNewDesign);
 		const cssPath = isNewDesign ?
 			path.join(__dirname, '..', 'css', 'new-design') :
 			path.join(__dirname, '..', 'css');


### PR DESCRIPTION
Enable Facebook dark mode when option is turned on and add patches to the integrated dark mode.

Closes: #1452 