### PR TITLE
Add Adwaita-style CSDs (Client-Side Decorations)

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -39,3 +39,7 @@ html.hide-dropdowns [role=menu].l9j0dhe7.swg4t2nn {
 }
 
 body::-webkit-scrollbar { width: 0px; }
+
+.nhd2j8a9 {
+	cursor: default !important;
+}

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -7,6 +7,7 @@ html.hide-dropdowns [role=menu].l9j0dhe7.swg4t2nn {
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.jei6r52m.wkznzc2l.n851cfcs.dhix69tm.ahb00how,
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.hv4rvrfc.dati1w0a.f10w8fjw.pybr56ya.b5q2rw42.lq239pai.mysgfdmx.hddg9phg {
 	-webkit-app-region: drag !important;
+	-webkit-user-select: none;
 }
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.jei6r52m.wkznzc2l.n851cfcs.dhix69tm.ahb00how {
 	margin: 0 !important;

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -23,3 +23,18 @@ html.hide-dropdowns [role=menu].l9j0dhe7.swg4t2nn {
 		padding-top: 36px !important;
 	}
 }
+
+/* Disable drag for info and call buttons on the top right corner */
+.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.pfnyh3mw.d2edcug0.hpfvmrgz.p8fzw8mz.pcp91wgn.iuny7tx3.ipjc6fyt {
+	-webkit-app-region: no-drag !important;
+}
+/* Disable drag for status (below chat name) */
+.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.gk29lw5a.a8c37x1j.keod5gw0.nxhoafnm.aigsh9s9.tia6h79c.fe6kdd0r.mau55g9w.c8b282yb.iv3no6db.e9vueds3.j5wam9gi.knj5qynh.m9osqain.oqcyycmt {
+	-webkit-app-region: no-drag !important;
+}
+/* Disable drag for Settings, help and more; Create New Room; and New Message */
+.oajrlxb2.tdjehn4e.qu0x051f.esr5mh6w.e9989ue4.r7d6kgcz.rq0escxv.nhd2j8a9.j83agx80.p7hjln8o.kvgmc6g5.cxmmr5t8.oygrvhab.hcukyx3x.jb3vyjys.rz4wbd8a.qt6c0cv9.a8nywdso.i1ao9s8h.esuyzwwr.f1sip0of.lzcic4wl.l9j0dhe7.abiwlrkh.p8dawk7l.bp9cbjyn.s45kfl79.emlxlaya.bkmhp75w.spb7xbtv.rt8b4zig.n8ej3o3l.agehan2d.sk4xxmp2.taijpn5t.tv7at329.thwo4zme {
+	-webkit-app-region: no-drag !important;
+}
+
+body::-webkit-scrollbar { width: 0px; }

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -758,7 +758,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 	observeAutoscroll();
 
 	// Hook buttons observer
-	observeButtons();
+	if (config.get('clientSideDecoration')) {
+		observeButtons();
+	}
 });
 
 // Handle title bar double-click.

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -368,12 +368,12 @@ function updateVibrancy(): void {
 }
 
 function updateCloseButton(): void {
-	const closeButton = document.querySelector("#close-button path");
+	const closeButton = document.querySelector('#close-button path');
 	if (closeButton) {
 		if (config.get('darkMode')) {
-			closeButton.setAttribute("fill", "#d1cbc9");
+			closeButton.setAttribute('fill', '#d1cbc9');
 		} else {
-			closeButton.setAttribute("fill", "#2e3436");
+			closeButton.setAttribute('fill', '#2e3436');
 		}
 	}
 }

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -6,6 +6,7 @@ import config from './config';
 import {toggleVideoAutoplay} from './autoplay';
 import {sendConversationList} from './browser/conversation-list';
 import {INewDesign, IToggleMuteNotifications, IToggleSounds} from './types';
+import electron = require('electron');
 
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 const selectedConversationNewDesign = '[role=navigation] [role=grid] [role=row] [role=link] > div:only-child';
@@ -15,16 +16,7 @@ const messengerSoundsSelector = `${preferencesSelector} ._374d ._6bkz`;
 const conversationMenuSelector = '.uiLayer:not(.hidden_elem) [role=menu]';
 const conversationMenuSelectorNewDesign = '[role=menu].l9j0dhe7.swg4t2nn';
 
-const remote = require('electron').remote;
-const win = remote.getCurrentWindow();
-
-
-window.onbeforeunload = (_event: Event) => {
-    /* If window is reloaded, remove win event listeners
-    (DOM element listeners get auto garbage collected but not
-    Electron win listeners as the win is not dereferenced unless closed) */
-    win.removeAllListeners();
-}
+const win = electron.remote.getCurrentWindow();
 
 async function withMenu(
 	isNewDesign: boolean,
@@ -641,31 +633,29 @@ function insertionListener(event: AnimationEvent): void {
 }
 
 function createButton() {
-    // Insert window close button
-    if (!document.querySelector("#close-button")) {
-        const nodes = document.querySelectorAll<HTMLElement>(".rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.b5q2rw42.lq239pai.mysgfdmx.hddg9phg")
-        if (nodes) {
-            const buttons = <HTMLElement>nodes[1];
-            if (buttons) {
-                buttons.insertAdjacentHTML('beforeend', '<div id=\"close-button\" class=\"rq0escxv l9j0dhe7 du4w35lb j83agx80 cbu4d94t pfnyh3mw d2edcug0 hpfvmrgz p8fzw8mz pcp91wgn iuny7tx3 ipjc6fyt bp9cbjyn qu8okrzs taijpn5t eim337gk\">\n    <span class=\"tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41\">\n        <div aria-label=\"Conversation Information\" class=\"oajrlxb2 gs1a9yip g5ia77u1 mtkw9kbi tlpljxtp qensuy8j ppp5ayq2 goun2846 ccm00jje s44p3ltw mk2mc5f4 rt8b4zig n8ej3o3l agehan2d sk4xxmp2 rq0escxv nhd2j8a9 pq6dq46d mg4g778l btwxx1t3 pfnyh3mw p7hjln8o kvgmc6g5 cxmmr5t8 oygrvhab hcukyx3x tgvbjcpo hpfvmrgz jb3vyjys rz4wbd8a qt6c0cv9 a8nywdso l9j0dhe7 i1ao9s8h esuyzwwr f1sip0of du4w35lb lzcic4wl abiwlrkh p8dawk7l\" role=\"button\" tabindex=\"0\">\n            <div class=\"bp9cbjyn pq6dq46d mudddibn taijpn5t l9j0dhe7 ciadx1gn\">\n                <div class=\"j9ispegn pmk7jnqg k4urcfbm datstx6m b5wmifdl kr520xx4 mdpwds66 b2cqd1jy n13yt9zj eh67sqbx\" style=\"background-color: rgb(0, 153, 255);\"></div>\n\n                <svg role=\"presentation\" width=\"16\" height=\"16\">\n                    <path d=\"M4 4h1.031c.255.011.51.129.688.313L8 6.592l2.312-2.28c.266-.231.447-.306.688-.313h1v1c0 .286-.034.55-.25.75L9.469 8.031l2.25 2.25c.188.188.281.454.281.719v1h-1c-.265 0-.53-.093-.719-.281L8 9.438l-2.281 2.28A1.015 1.015 0 015 12H4v-1c0-.265.093-.53.281-.719l2.281-2.25-2.28-2.281A.909.909 0 014 5z\" style=\"line-height:normal;-inkscape-font-specification:\'Andale Mono\';text-indent:0;text-align:start;text-decoration-line:none;text-transform:none;marker:none\" color=\"#bebebe\" font-weight=\"400\" font-family=\"Andale Mono\" overflow=\"visible\" fill=\"#2e3436\"/>\n                </svg>\n            </div>\n        </div>\n    </span>\n</div>\n');
-                buttons.childNodes[3].addEventListener("click", _event => {
-                        win.close();
-                });
-            }
-        }
-    }
+	// Insert window close button
+	if (!document.querySelector('#close-button')) {
+		// This selector selects both the name div and the buttons div, in that order,
+		// so I need to choose the second element.
+		const buttons = document.querySelectorAll('.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.b5q2rw42.lq239pai.mysgfdmx.hddg9phg')[1] as HTMLElement;
+		if (buttons) {
+			buttons.insertAdjacentHTML('beforeend', '<div id="close-button" class="rq0escxv l9j0dhe7 du4w35lb j83agx80 cbu4d94t pfnyh3mw d2edcug0 hpfvmrgz p8fzw8mz pcp91wgn iuny7tx3 ipjc6fyt bp9cbjyn qu8okrzs taijpn5t eim337gk"><span class="tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41"><div class="oajrlxb2 gs1a9yip g5ia77u1 mtkw9kbi tlpljxtp qensuy8j ppp5ayq2 goun2846 ccm00jje s44p3ltw mk2mc5f4 rt8b4zig n8ej3o3l agehan2d sk4xxmp2 rq0escxv nhd2j8a9 pq6dq46d mg4g778l btwxx1t3 pfnyh3mw p7hjln8o kvgmc6g5 cxmmr5t8 oygrvhab hcukyx3x tgvbjcpo hpfvmrgz jb3vyjys rz4wbd8a qt6c0cv9 a8nywdso l9j0dhe7 i1ao9s8h esuyzwwr f1sip0of du4w35lb lzcic4wl abiwlrkh p8dawk7l" role="button" tabindex="0"><div class="bp9cbjyn pq6dq46d mudddibn taijpn5t l9j0dhe7 ciadx1gn"><div class="j9ispegn pmk7jnqg k4urcfbm datstx6m b5wmifdl kr520xx4 mdpwds66 b2cqd1jy n13yt9zj eh67sqbx" style="background-color: rgb(0, 153, 255);"></div><svg role="presentation" width="16" height="16"><path d="M4 4h1.031c.255.011.51.129.688.313L8 6.592l2.312-2.28c.266-.231.447-.306.688-.313h1v1c0 .286-.034.55-.25.75L9.469 8.031l2.25 2.25c.188.188.281.454.281.719v1h-1c-.265 0-.53-.093-.719-.281L8 9.438l-2.281 2.28A1.015 1.015 0 015 12H4v-1c0-.265.093-.53.281-.719l2.281-2.25-2.28-2.281A.909.909 0 014 5z" style="line-height:normal;-inkscape-font-specification:\'Andale Mono\';text-indent:0;text-align:start;text-decoration-line:none;text-transform:none;marker:none" color="#bebebe" font-weight="400" font-family="Andale Mono" overflow="visible" fill="#2e3436"/></svg></div></div></span></div>');
+			buttons.childNodes[3].addEventListener('click', _event => {
+				win.close();
+			});
+		}
+	}
 }
 
-
 async function observeButtons(): Promise<void> {
-    const mainElement = await elementReady<HTMLElement>('.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.g5gj957u.d2edcug0.hpfvmrgz.rj1gh0hx.buofh1pr.dp1hu0rb', {stopOnDomReady: false});
-    if (mainElement) {
-        const observer = new MutationObserver(createButton);
-        observer.observe(mainElement, {
-            childList: true,
-            subtree: true
-        });
-    }
+	const mainElement = await elementReady<HTMLElement>('.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.g5gj957u.d2edcug0.hpfvmrgz.rj1gh0hx.buofh1pr.dp1hu0rb', {stopOnDomReady: false});
+	if (mainElement) {
+		const observer = new MutationObserver(createButton);
+		observer.observe(mainElement, {
+			childList: true,
+			subtree: true
+		});
+	}
 }
 
 async function observeAutoscroll(): Promise<void> {
@@ -697,9 +687,9 @@ async function observeAutoscroll(): Promise<void> {
 				const newMessages: MutationRecord[] = record.filter(record => {
 					// The mutation is an addition
 					return record.addedNodes.length > 0 &&
-						// ... of a div       (skip the "seen" status change)
+						// ... of a div		  (skip the "seen" status change)
 						(record.addedNodes[0] as HTMLElement).tagName === 'DIV' &&
-						// ... on the last child       (skip previous messages added when scrolling up)
+						// ... on the last child	   (skip previous messages added when scrolling up)
 						chatElement.lastChild!.contains(record.target);
 				});
 
@@ -719,6 +709,11 @@ async function observeAutoscroll(): Promise<void> {
 	const conversationObserver = new MutationObserver(hookMessageObserver);
 	conversationObserver.observe(mainElement, {childList: true});
 }
+
+// Remove win event listeners on exit
+window.addEventListener('onbeforeunload', _event => {
+	win.removeAllListeners();
+});
 
 // Listen for emoji element dom insertion
 document.addEventListener('animationstart', insertionListener, false);
@@ -764,7 +759,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Hook buttons observer
 	observeButtons();
-
 });
 
 // Handle title bar double-click.

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -640,9 +640,12 @@ function createButton() {
 		const buttons = document.querySelectorAll('.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.b5q2rw42.lq239pai.mysgfdmx.hddg9phg')[1] as HTMLElement;
 		if (buttons) {
 			buttons.insertAdjacentHTML('beforeend', '<div id="close-button" class="rq0escxv l9j0dhe7 du4w35lb j83agx80 cbu4d94t pfnyh3mw d2edcug0 hpfvmrgz p8fzw8mz pcp91wgn iuny7tx3 ipjc6fyt bp9cbjyn qu8okrzs taijpn5t eim337gk"><span class="tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41"><div class="oajrlxb2 gs1a9yip g5ia77u1 mtkw9kbi tlpljxtp qensuy8j ppp5ayq2 goun2846 ccm00jje s44p3ltw mk2mc5f4 rt8b4zig n8ej3o3l agehan2d sk4xxmp2 rq0escxv nhd2j8a9 pq6dq46d mg4g778l btwxx1t3 pfnyh3mw p7hjln8o kvgmc6g5 cxmmr5t8 oygrvhab hcukyx3x tgvbjcpo hpfvmrgz jb3vyjys rz4wbd8a qt6c0cv9 a8nywdso l9j0dhe7 i1ao9s8h esuyzwwr f1sip0of du4w35lb lzcic4wl abiwlrkh p8dawk7l" role="button" tabindex="0"><div class="bp9cbjyn pq6dq46d mudddibn taijpn5t l9j0dhe7 ciadx1gn"><div class="j9ispegn pmk7jnqg k4urcfbm datstx6m b5wmifdl kr520xx4 mdpwds66 b2cqd1jy n13yt9zj eh67sqbx" style="background-color: rgb(0, 153, 255);"></div><svg role="presentation" width="16" height="16"><path d="M4 4h1.031c.255.011.51.129.688.313L8 6.592l2.312-2.28c.266-.231.447-.306.688-.313h1v1c0 .286-.034.55-.25.75L9.469 8.031l2.25 2.25c.188.188.281.454.281.719v1h-1c-.265 0-.53-.093-.719-.281L8 9.438l-2.281 2.28A1.015 1.015 0 015 12H4v-1c0-.265.093-.53.281-.719l2.281-2.25-2.28-2.281A.909.909 0 014 5z" style="line-height:normal;-inkscape-font-specification:\'Andale Mono\';text-indent:0;text-align:start;text-decoration-line:none;text-transform:none;marker:none" color="#bebebe" font-weight="400" font-family="Andale Mono" overflow="visible" fill="#2e3436"/></svg></div></div></span></div>');
-			buttons.childNodes[3].addEventListener('click', _event => {
-				win.close();
-			});
+			const closeButton = document.querySelector('#close-button');
+			if (closeButton) {
+				closeButton.addEventListener('click', _event => {
+					win.close();
+				});
+			}
 		}
 	}
 }

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -337,6 +337,8 @@ function setDarkMode(): void {
 	document.documentElement.classList.toggle('__fb-dark-mode', api.nativeTheme.shouldUseDarkColors);
 
 	updateVibrancy();
+
+	updateCloseButton();
 }
 
 function setPrivateMode(): void {
@@ -363,6 +365,17 @@ function updateVibrancy(): void {
 	}
 
 	ipc.callMain('set-vibrancy');
+}
+
+function updateCloseButton(): void {
+	const closeButton = document.querySelector("#close-button path");
+	if (closeButton) {
+		if (config.get('darkMode')) {
+			closeButton.setAttribute("fill", "#d1cbc9");
+		} else {
+			closeButton.setAttribute("fill", "#2e3436");
+		}
+	}
 }
 
 function updateSidebar(): void {
@@ -642,6 +655,7 @@ function createButton() {
 			buttons.insertAdjacentHTML('beforeend', '<div id="close-button" class="rq0escxv l9j0dhe7 du4w35lb j83agx80 cbu4d94t pfnyh3mw d2edcug0 hpfvmrgz p8fzw8mz pcp91wgn iuny7tx3 ipjc6fyt bp9cbjyn qu8okrzs taijpn5t eim337gk"><span class="tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41"><div class="oajrlxb2 gs1a9yip g5ia77u1 mtkw9kbi tlpljxtp qensuy8j ppp5ayq2 goun2846 ccm00jje s44p3ltw mk2mc5f4 rt8b4zig n8ej3o3l agehan2d sk4xxmp2 rq0escxv nhd2j8a9 pq6dq46d mg4g778l btwxx1t3 pfnyh3mw p7hjln8o kvgmc6g5 cxmmr5t8 oygrvhab hcukyx3x tgvbjcpo hpfvmrgz jb3vyjys rz4wbd8a qt6c0cv9 a8nywdso l9j0dhe7 i1ao9s8h esuyzwwr f1sip0of du4w35lb lzcic4wl abiwlrkh p8dawk7l" role="button" tabindex="0"><div class="bp9cbjyn pq6dq46d mudddibn taijpn5t l9j0dhe7 ciadx1gn"><div class="j9ispegn pmk7jnqg k4urcfbm datstx6m b5wmifdl kr520xx4 mdpwds66 b2cqd1jy n13yt9zj eh67sqbx" style="background-color: rgb(0, 153, 255);"></div><svg role="presentation" width="16" height="16"><path d="M4 4h1.031c.255.011.51.129.688.313L8 6.592l2.312-2.28c.266-.231.447-.306.688-.313h1v1c0 .286-.034.55-.25.75L9.469 8.031l2.25 2.25c.188.188.281.454.281.719v1h-1c-.265 0-.53-.093-.719-.281L8 9.438l-2.281 2.28A1.015 1.015 0 015 12H4v-1c0-.265.093-.53.281-.719l2.281-2.25-2.28-2.281A.909.909 0 014 5z" style="line-height:normal;-inkscape-font-specification:\'Andale Mono\';text-indent:0;text-align:start;text-decoration-line:none;text-transform:none;marker:none" color="#bebebe" font-weight="400" font-family="Andale Mono" overflow="visible" fill="#2e3436"/></svg></div></div></span></div>');
 			const closeButton = document.querySelector('#close-button');
 			if (closeButton) {
+				updateCloseButton();
 				closeButton.addEventListener('click', _event => {
 					win.close();
 				});

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -15,6 +15,17 @@ const messengerSoundsSelector = `${preferencesSelector} ._374d ._6bkz`;
 const conversationMenuSelector = '.uiLayer:not(.hidden_elem) [role=menu]';
 const conversationMenuSelectorNewDesign = '[role=menu].l9j0dhe7.swg4t2nn';
 
+const remote = require('electron').remote;
+const win = remote.getCurrentWindow();
+
+
+window.onbeforeunload = (_event: Event) => {
+    /* If window is reloaded, remove win event listeners
+    (DOM element listeners get auto garbage collected but not
+    Electron win listeners as the win is not dereferenced unless closed) */
+    win.removeAllListeners();
+}
+
 async function withMenu(
 	isNewDesign: boolean,
 	menuButtonElement: HTMLElement,
@@ -629,6 +640,34 @@ function insertionListener(event: AnimationEvent): void {
 	}
 }
 
+function createButton() {
+    // Insert window close button
+    if (!document.querySelector("#close-button")) {
+        const nodes = document.querySelectorAll<HTMLElement>(".rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.b5q2rw42.lq239pai.mysgfdmx.hddg9phg")
+        if (nodes) {
+            const buttons = <HTMLElement>nodes[1];
+            if (buttons) {
+                buttons.insertAdjacentHTML('beforeend', '<div id=\"close-button\" class=\"rq0escxv l9j0dhe7 du4w35lb j83agx80 cbu4d94t pfnyh3mw d2edcug0 hpfvmrgz p8fzw8mz pcp91wgn iuny7tx3 ipjc6fyt bp9cbjyn qu8okrzs taijpn5t eim337gk\">\n    <span class=\"tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41\">\n        <div aria-label=\"Conversation Information\" class=\"oajrlxb2 gs1a9yip g5ia77u1 mtkw9kbi tlpljxtp qensuy8j ppp5ayq2 goun2846 ccm00jje s44p3ltw mk2mc5f4 rt8b4zig n8ej3o3l agehan2d sk4xxmp2 rq0escxv nhd2j8a9 pq6dq46d mg4g778l btwxx1t3 pfnyh3mw p7hjln8o kvgmc6g5 cxmmr5t8 oygrvhab hcukyx3x tgvbjcpo hpfvmrgz jb3vyjys rz4wbd8a qt6c0cv9 a8nywdso l9j0dhe7 i1ao9s8h esuyzwwr f1sip0of du4w35lb lzcic4wl abiwlrkh p8dawk7l\" role=\"button\" tabindex=\"0\">\n            <div class=\"bp9cbjyn pq6dq46d mudddibn taijpn5t l9j0dhe7 ciadx1gn\">\n                <div class=\"j9ispegn pmk7jnqg k4urcfbm datstx6m b5wmifdl kr520xx4 mdpwds66 b2cqd1jy n13yt9zj eh67sqbx\" style=\"background-color: rgb(0, 153, 255);\"></div>\n\n                <svg role=\"presentation\" width=\"16\" height=\"16\">\n                    <path d=\"M4 4h1.031c.255.011.51.129.688.313L8 6.592l2.312-2.28c.266-.231.447-.306.688-.313h1v1c0 .286-.034.55-.25.75L9.469 8.031l2.25 2.25c.188.188.281.454.281.719v1h-1c-.265 0-.53-.093-.719-.281L8 9.438l-2.281 2.28A1.015 1.015 0 015 12H4v-1c0-.265.093-.53.281-.719l2.281-2.25-2.28-2.281A.909.909 0 014 5z\" style=\"line-height:normal;-inkscape-font-specification:\'Andale Mono\';text-indent:0;text-align:start;text-decoration-line:none;text-transform:none;marker:none\" color=\"#bebebe\" font-weight=\"400\" font-family=\"Andale Mono\" overflow=\"visible\" fill=\"#2e3436\"/>\n                </svg>\n            </div>\n        </div>\n    </span>\n</div>\n');
+                buttons.childNodes[3].addEventListener("click", _event => {
+                        win.close();
+                });
+            }
+        }
+    }
+}
+
+
+async function observeButtons(): Promise<void> {
+    const mainElement = await elementReady<HTMLElement>('.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.g5gj957u.d2edcug0.hpfvmrgz.rj1gh0hx.buofh1pr.dp1hu0rb', {stopOnDomReady: false});
+    if (mainElement) {
+        const observer = new MutationObserver(createButton);
+        observer.observe(mainElement, {
+            childList: true,
+            subtree: true
+        });
+    }
+}
+
 async function observeAutoscroll(): Promise<void> {
 	const mainElement = await elementReady<HTMLElement>('._4sp8', {stopOnDomReady: false});
 	if (!mainElement) {
@@ -722,6 +761,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Hook auto-scroll observer
 	observeAutoscroll();
+
+	// Hook buttons observer
+	observeButtons();
+
 });
 
 // Handle title bar double-click.

--- a/source/config.ts
+++ b/source/config.ts
@@ -34,6 +34,7 @@ type StoreType = {
 	useWorkChat: boolean;
 	sidebar: 'default' | 'hidden' | 'narrow' | 'wide';
 	autoHideMenuBar: boolean;
+	clientSideDecoration: boolean;
 	notificationsMuted: boolean;
 	callRingtoneMuted: boolean;
 	hardwareAcceleration: boolean;
@@ -172,6 +173,10 @@ const schema: Store.Schema<StoreType> = {
 		default: 'default'
 	},
 	autoHideMenuBar: {
+		type: 'boolean',
+		default: false
+	},
+	clientSideDecoration: {
 		type: 'boolean',
 		default: false
 	},

--- a/source/index.ts
+++ b/source/index.ts
@@ -295,7 +295,7 @@ function createMainWindow(): BrowserWindow {
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
 		darkTheme: isDarkMode, // GTK+3
-		frame: false,
+		frame: !config.get('clientSideDecoration'),
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -295,7 +295,7 @@ function createMainWindow(): BrowserWindow {
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
 		darkTheme: isDarkMode, // GTK+3
-                frame: false,
+		frame: false,
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -295,6 +295,7 @@ function createMainWindow(): BrowserWindow {
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
 		darkTheme: isDarkMode, // GTK+3
+                frame: false,
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -338,6 +338,16 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			label: 'Use Client-side Decoration',
+			type: 'checkbox',
+			visible: !is.macos,
+			checked: config.get('clientSideDecoration'),
+			click(menuItem) {
+				config.set('clientSideDecoration', menuItem.checked);
+				showRestartDialog('Caprine needs to be restarted to enable or disable client-side decoration.');
+			}
+		},
+		{
 			label: 'Flash Window on Message',
 			type: 'checkbox',
 			visible: !is.macos,


### PR DESCRIPTION
This is a work-in-progress for adding CSDs to Caprine. The CSDs I added should work on Windows (although I haven't tested it), but the close button uses the Adwaita icon theme, so these CSDs are meant for Linux.

GNOME CSD Initiative: https://blogs.gnome.org/tbernard/2018/01/26/csd-initiative/

Advantages:
* Uses less space
* Fits the GNOME style
* Useful for users of electron-ozone since they might not have title bars.

Current Issues:
* Cannot resize from draggable region
* ~Close button does not work for messages to yourself~ Fixed
* Menu bar doesn't show
* ~No configuration option~ Done
* ~Doesn't change colors with dark mode~ Fixed
* ~Draggable region can be selected~ Fixed

Without CSDs:
![nocsd](https://user-images.githubusercontent.com/13303232/106398139-f8def300-63c5-11eb-8ae7-84508ff6b77d.png)

With CSDs:
![csd](https://user-images.githubusercontent.com/13303232/106398136-f7152f80-63c5-11eb-8927-6708c77cc960.png)