### PR TITLE
Hide disabled scroll bar

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -1,3 +1,8 @@
+/* Hide disabled scrollbar on the right side */
+body::-webkit-scrollbar {
+	width: 0;
+}
+
 /* A utility class for temporarily hiding all dropdown menus */
 html.hide-dropdowns [role=menu].l9j0dhe7.swg4t2nn {
 	visibility: hidden !important;


### PR DESCRIPTION
There is a disabled scroll bar on the right side of the app window.
Since it is disabled, it can't be used to to scroll anything and it's
basically useless. This just hides it from view so it won't get in the
way of using the app.