### PR TITLE
Fix preferences opening on startup

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -8,6 +8,13 @@ html.hide-dropdowns [role=menu].l9j0dhe7.swg4t2nn {
 	visibility: hidden !important;
 }
 
+/* A utility class for temporarily hiding preferences window */
+html.hide-preferences-window [data-pagelet=root] > div > div:last-child {
+	display: none;
+	opacity: 0;
+	visibility: hidden;
+}
+
 /* Dragable region for macOS */
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.jei6r52m.wkznzc2l.n851cfcs.dhix69tm.ahb00how,
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.hv4rvrfc.dati1w0a.f10w8fjw.pybr56ya.b5q2rw42.lq239pai.mysgfdmx.hddg9phg {

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -11,8 +11,6 @@ html.hide-dropdowns [role=menu].l9j0dhe7.swg4t2nn {
 /* A utility class for temporarily hiding preferences window */
 html.hide-preferences-window [data-pagelet=root] > div > div:last-child {
 	display: none;
-	opacity: 0;
-	visibility: hidden;
 }
 
 /* A utility class for temporarily hiding right sidebar */

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -13,6 +13,7 @@ html.hide-preferences-window [data-pagelet=root] > div > div:last-child {
 	display: none;
 	opacity: 0;
 	visibility: hidden;
+}
 
 /* A utility class for temporarily hiding right sidebar */
 html.hide-r-sidebar .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.gs1a9yip.owycx6da.btwxx1t3.jb3vyjys.nwf6jgls > div:nth-child(2) {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -336,7 +336,7 @@ ipc.answerMain('toggle-mute-notifications', async ({isNewDesign, defaultStatus}:
 		closePreferences(isNewDesign);
 	}
 
-	return !notificationCheckbox.checked;
+	return !isNewDesign && !notificationCheckbox.checked;
 });
 
 ipc.answerMain('toggle-message-buttons', () => {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -236,14 +236,16 @@ ipc.answerMain('hide-conversation', async ({isNewDesign}: INewDesign) => {
 	}
 });
 
-async function openHiddenPreferences(isNewDesign: boolean): Promise<boolean> {
+async function openHiddenPreferences(isNewDesign: boolean, firstStart = false): Promise<boolean> {
 	if (!isPreferencesOpen(isNewDesign)) {
 		const style = document.createElement('style');
 		// Hide both the backdrop and the preferences dialog
 		style.textContent = `${preferencesSelector} ._3ixn, ${preferencesSelector} ._59s7 { opacity: 0 !important }`;
 		document.body.append(style);
 
-		await openPreferences(isNewDesign);
+		if (!firstStart) {
+			await openPreferences(isNewDesign);
+		}
 
 		// Will clean up itself after the preferences are closed
 		document.querySelector<HTMLElement>(preferencesSelector)!.append(style);
@@ -381,8 +383,8 @@ function updateSidebar(): void {
 	}
 }
 
-async function updateDoNotDisturb(isNewDesign: boolean): Promise<void> {
-	const shouldClosePreferences = await openHiddenPreferences(isNewDesign);
+async function updateDoNotDisturb(isNewDesign: boolean, firstStart = false): Promise<void> {
+	const shouldClosePreferences = await openHiddenPreferences(isNewDesign, firstStart);
 	const soundsCheckbox = document.querySelector<HTMLInputElement>(messengerSoundsSelector)!;
 
 	if (shouldClosePreferences) {
@@ -708,7 +710,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Configure do not disturb
 	if (is.macos) {
-		await updateDoNotDisturb(await isNewDesign());
+		await updateDoNotDisturb(await isNewDesign(), true);
 	}
 
 	// Prevent flash of white on startup when in dark mode

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -236,19 +236,26 @@ ipc.answerMain('hide-conversation', async ({isNewDesign}: INewDesign) => {
 	}
 });
 
-async function openHiddenPreferences(isNewDesign: boolean, firstStart = false): Promise<boolean> {
+async function openHiddenPreferences(isNewDesign: boolean): Promise<boolean> {
 	if (!isPreferencesOpen(isNewDesign)) {
 		const style = document.createElement('style');
 		// Hide both the backdrop and the preferences dialog
 		style.textContent = `${preferencesSelector} ._3ixn, ${preferencesSelector} ._59s7 { opacity: 0 !important }`;
-		document.body.append(style);
 
-		if (!firstStart) {
-			await openPreferences(isNewDesign);
+		if (!isNewDesign) {
+			document.body.append(style);
 		}
 
-		// Will clean up itself after the preferences are closed
-		document.querySelector<HTMLElement>(preferencesSelector)!.append(style);
+		await openPreferences(isNewDesign);
+
+		if (!isNewDesign) {
+			// Will clean up itself after the preferences are closed
+			document.querySelector<HTMLElement>(preferencesSelector)!.append(style);
+		}
+
+		if (isNewDesign) {
+			closePreferences(isNewDesign);
+		}
 
 		return true;
 	}
@@ -383,8 +390,8 @@ function updateSidebar(): void {
 	}
 }
 
-async function updateDoNotDisturb(isNewDesign: boolean, firstStart = false): Promise<void> {
-	const shouldClosePreferences = await openHiddenPreferences(isNewDesign, firstStart);
+async function updateDoNotDisturb(isNewDesign: boolean): Promise<void> {
+	const shouldClosePreferences = await openHiddenPreferences(isNewDesign);
 	const soundsCheckbox = document.querySelector<HTMLInputElement>(messengerSoundsSelector)!;
 
 	if (shouldClosePreferences) {
@@ -710,7 +717,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Configure do not disturb
 	if (is.macos) {
-		await updateDoNotDisturb(await isNewDesign(), true);
+		await updateDoNotDisturb(await isNewDesign());
 	}
 
 	// Prevent flash of white on startup when in dark mode

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -665,8 +665,22 @@ function isPreferencesOpen(isNewDesign: boolean): boolean {
 function closePreferences(isNewDesign: boolean): void {
 	if (isNewDesign) {
 		const closeButton = document.querySelector<HTMLElement>('[aria-label=Preferences] [aria-label=Close]')!;
-		document.documentElement.classList.remove('hide-preferences-window');
-		return closeButton.click();
+		closeButton.click();
+
+		// Wait for the preferences window to be closed, then remove the class from the document
+		const preferencesOverlayObserver = new MutationObserver(records => {
+			const removedRecords = records.filter(({removedNodes}) => removedNodes.length > 0 && (removedNodes[0] as HTMLElement).tagName === 'DIV');
+
+			// In case there is a div removed, hide utility class and stop observing
+			if (removedRecords.length > 0) {
+				document.documentElement.classList.remove('hide-preferences-window');
+				preferencesOverlayObserver.disconnect();
+			}
+		});
+
+		const preferencesOverlay = document.querySelector('[data-pagelet=root] > div > div:last-child')!;
+
+		return preferencesOverlayObserver.observe(preferencesOverlay, {childList: true, subtree: true});
 	}
 
 	const doneButton = document.querySelector<HTMLElement>('._3quh._30yy._2t_._5ixy')!;

--- a/source/index.ts
+++ b/source/index.ts
@@ -377,6 +377,8 @@ function createMainWindow(): BrowserWindow {
 
 (async () => {
 	await Promise.all([ensureOnline(), app.whenReady()]);
+	// ! const isNewDesign = Boolean(await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui'));
+	// This is never resolved, making the app stuck here ☝️
 	await updateAppMenu({isNewDesign: false});
 	mainWindow = createMainWindow();
 
@@ -394,7 +396,8 @@ function createMainWindow(): BrowserWindow {
 			type: 'checkbox',
 			checked: config.get('notificationsMuted'),
 			async click() {
-				setNotificationsMute(await ipcMain.callRenderer(mainWindow, 'toggle-mute-notifications'));
+				const isNewDesign = Boolean(await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui'));
+				setNotificationsMute(await ipcMain.callRenderer(mainWindow, 'toggle-mute-notifications', {isNewDesign}));
 			}
 		};
 
@@ -490,7 +493,11 @@ function createMainWindow(): BrowserWindow {
 			});
 		}
 
-		setNotificationsMute(await ipcMain.callRenderer(mainWindow, 'toggle-mute-notifications', config.get('notificationsMuted')));
+		setNotificationsMute(await ipcMain.callRenderer(mainWindow, 'toggle-mute-notifications', {
+			isNewDesign,
+			defaultStatus: config.get('notificationsMuted')
+		}));
+
 		ipcMain.callRenderer(mainWindow, 'toggle-message-buttons', config.get('showMessageButtons'));
 
 		await webContents.executeJavaScript(

--- a/source/index.ts
+++ b/source/index.ts
@@ -394,7 +394,7 @@ function createMainWindow(): BrowserWindow {
 			type: 'checkbox',
 			checked: config.get('notificationsMuted'),
 			async click() {
-				const isNewDesign = Boolean(await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui'));
+				const isNewDesign = await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui');
 				setNotificationsMute(await ipcMain.callRenderer(mainWindow, 'toggle-mute-notifications', {isNewDesign}));
 			}
 		};

--- a/source/index.ts
+++ b/source/index.ts
@@ -443,7 +443,7 @@ function createMainWindow(): BrowserWindow {
 	const {webContents} = mainWindow;
 
 	webContents.on('dom-ready', async () => {
-		const isNewDesign = Boolean(await ipcMain.callRenderer<undefined, Element>(mainWindow, 'check-new-ui'));
+		const isNewDesign = await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui');
 
 		await updateAppMenu({isNewDesign});
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -377,8 +377,6 @@ function createMainWindow(): BrowserWindow {
 
 (async () => {
 	await Promise.all([ensureOnline(), app.whenReady()]);
-	// ! const isNewDesign = Boolean(await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui'));
-	// This is never resolved, making the app stuck here ☝️
 	await updateAppMenu({isNewDesign: false});
 	mainWindow = createMainWindow();
 


### PR DESCRIPTION
This PR adds a boolean flag for the `updateDoNotDisturb` and `openHiddenPreferences` functions, to prevent the preferences window from opening on startup. I know its not the best solution, but gets the job done for now(:

fixes #1547 