### PR TITLE
Fix conversation list on new UI

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -383,11 +383,11 @@ function setDarkMode(): void {
 	updateVibrancy();
 }
 
-function setPrivateMode(): void {
+function setPrivateMode(isNewDesign: boolean): void {
 	document.documentElement.classList.toggle('private-mode', config.get('privateMode'));
 
 	if (is.macos) {
-		sendConversationList();
+		sendConversationList(isNewDesign);
 	}
 }
 
@@ -750,13 +750,15 @@ document.addEventListener('animationstart', insertionListener, false);
 
 // Inject a global style node to maintain custom appearance after conversation change or startup
 document.addEventListener('DOMContentLoaded', async () => {
+	const newDesign = await isNewDesign();
+
 	const style = document.createElement('style');
 	style.id = 'zoomFactor';
 	document.body.append(style);
 
 	// Set the zoom factor if it was set before quitting
 	const zoomFactor = config.get('zoomFactor');
-	setZoom(await isNewDesign(), zoomFactor);
+	setZoom(newDesign, zoomFactor);
 
 	// Enable OS specific styles
 	document.documentElement.classList.add(`os-${process.platform}`);
@@ -768,11 +770,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 	setDarkMode();
 
 	// Activate Private Mode if it was set before quitting
-	setPrivateMode();
+	setPrivateMode(newDesign);
 
 	// Configure do not disturb
 	if (is.macos) {
-		await updateDoNotDisturb(await isNewDesign());
+		await updateDoNotDisturb(newDesign);
 	}
 
 	// Prevent flash of white on startup when in dark mode
@@ -932,7 +934,7 @@ ipc.answerMain('notification-reply-callback', async (data: any) => {
 	window.postMessage({type: 'notification-reply-callback', data}, '*');
 });
 
-async function isNewDesign(): Promise<boolean> {
+export async function isNewDesign(): Promise<boolean> {
 	return Boolean(await elementReady('._9dls', {stopOnDomReady: false}));
 }
 

--- a/source/browser/selectors.ts
+++ b/source/browser/selectors.ts
@@ -4,5 +4,6 @@ export default {
 	conversationSelector: '._4u-c._1wfr .__i_, ._4u-c._1wfr #conversationWindow',
 	conversationSelectorNewDesign: '[role=main] [role=grid]',
 	notificationCheckbox: '._374b:nth-of-type(4) ._4ng2 input',
-	rightSidebarButtons: '.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.g5gj957u.f4tghd1a.ifue306u.kuivcneq.t63ysoy8 [role=button]'
+	rightSidebarButtons: '.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.cbu4d94t.g5gj957u.f4tghd1a.ifue306u.kuivcneq.t63ysoy8 [role=button]',
+	muteIconNewDesign: 'path[d="M29.676 7.746c.353-.352.44-.92.15-1.324a1 1 0 00-1.524-.129L6.293 28.29a1 1 0 00.129 1.523c.404.29.972.204 1.324-.148l3.082-3.08A2.002 2.002 0 0112.242 26h15.244c.848 0 1.57-.695 1.527-1.541-.084-1.643-1.87-1.145-2.2-3.515l-1.073-8.157-.002-.01a1.976 1.976 0 01.562-1.656l3.376-3.375zm-9.165 20.252H15.51c-.313 0-.565.275-.506.575.274 1.38 1.516 2.422 3.007 2.422 1.49 0 2.731-1.042 3.005-2.422.06-.3-.193-.575-.505-.575zm-10.064-6.719L22.713 9.02a.997.997 0 00-.124-1.51 7.792 7.792 0 00-12.308 5.279l-1.04 7.897c-.089.672.726 1.074 1.206.594z"]'
 };

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -462,13 +462,13 @@ Press Command/Ctrl+R in Caprine to see your changes.
 
 					if (result.response === 0) {
 						config.set('privateMode', !config.get('privateMode'));
-						sendAction('set-private-mode');
+						sendAction('set-private-mode', isNewDesign);
 					} else if (result.response === 1) {
 						menuItem.checked = false;
 					}
 				} else {
 					config.set('privateMode', !config.get('privateMode'));
-					sendAction('set-private-mode');
+					sendAction('set-private-mode', isNewDesign);
 				}
 			}
 		},


### PR DESCRIPTION
This would fix tray indicator for new messages, however there is one problem. The problem with excluding muted conversations from unread conversations is that once you get a new message in muted conversation, you lose the muted icon. The only way the to check if the conversation is muted is to open muted is to open conversation menu and check if there is an unmute button. The problem then arises when the user has already a different menu open which will result in closing of that menu. Because of that we cannot check if conversation is muted without causing unexpected behavior. Any thoughts on this issue are very welcome!

Closes: #1536
Closes: #1028 