### PR TITLE
fix "Create new room" icon color on dark mode

### DIFF
--- a/css/new-design/dark-mode.css
+++ b/css/new-design/dark-mode.css
@@ -16,6 +16,12 @@
 	color: var(--primary-text);
 }
 
+/* New room: Icon color */
+[aria-label="Create new room"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+	fill: currentColor;
+	color: var(--primary-text);
+}
+
 /* Menu: Icon color in menu */
 [role="menu"] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
 	fill: currentColor;


### PR DESCRIPTION
This makes the _Create new room_ icon in the top bar white in dark mode

Before:
<img width="162" alt="Screenshot 2021-02-25 at 22 24 42" src="https://user-images.githubusercontent.com/45368713/109219755-4f1e3680-77b8-11eb-97b9-bb89097cb253.png">

After:
<img width="154" alt="Screenshot 2021-02-25 at 22 24 09" src="https://user-images.githubusercontent.com/45368713/109219705-3b72d000-77b8-11eb-98d1-6010f520a2dc.png">

