### PR TITLE
Fix next and previous conversation shortcut

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -8,7 +8,7 @@ import {sendConversationList} from './browser/conversation-list';
 import {INewDesign, IToggleMuteNotifications, IToggleSounds} from './types';
 
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
-const selectedConversationNewDesign = '[role=navigation] [role=grid] [role=row] [role=link] > div:only-child';
+const selectedConversationNewDesign = '[role=navigation] [role=grid] [role=row] [role=gridcell] [role=link][aria-current]';
 const preferencesSelector = '._10._4ebx.uiLayer._4-hy';
 const preferencesSelectorNewDesign = '[aria-label=Preferences]';
 const messengerSoundsSelector = `${preferencesSelector} ._374d ._6bkz`;
@@ -597,7 +597,7 @@ function selectedConversationIndex(isNewDesign: boolean, offset = 0): number {
 	}
 
 	const newSelected = isNewDesign ?
-		selected.parentNode!.parentNode!.parentNode!.parentNode!.parentNode! as HTMLElement :
+		selected.parentNode!.parentNode!.parentNode! as HTMLElement :
 		selected;
 
 	const list = [...newSelected.parentNode!.children];


### PR DESCRIPTION
There were some minor ui changes that caused next and previous conversation shortcut to stop working. This is now fixed.