### PR TITLE
Add Fedora install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,12 @@ Or with [Homebrew](https://brew.sh): `$ brew install caprine`
 
 Arch Linux: `pacman -S caprine`
 
+Fedora:
+```
+sudo dnf copr enable dusansimic/caprine
+sudo dnf install caprine
+```
+
 Also available as a [snap](https://snapcraft.io/caprine).
 
 *The AppImage needs to be [made executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80) after download.*


### PR DESCRIPTION
Add installation instruction for Fedora. I've created an RPM build with COPR (a build system for rpm packages) which also creates a repo for the rpm. Now Caprine can be easily installed on Fedora.