### PR TITLE
Fix top gap

### DIFF
--- a/css/new-design/dark-mode.css
+++ b/css/new-design/dark-mode.css
@@ -41,3 +41,15 @@
 	fill: currentColor;
 	color: var(--primary-text);
 }
+
+/* Removing top gap */
+/* TODO: Remove when fixed by fb */
+html.dark-mode .be9z9djy {
+	top: 0;
+}
+html.dark-mode .jgljxmt5 {
+	min-height: 100vh;
+}
+html.dark-mode .gitj76qy {
+	max-height: 100vh;
+}


### PR DESCRIPTION
This fix was provided by @nforro in #1604. It removes the top gap in dark mode. This fix should be removed once Facebook fixes their dark mode css.

Closes: #1604 