### PR TITLE
Enable subpixel rendering on Linux

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -295,6 +295,7 @@ function createMainWindow(): BrowserWindow {
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
 		darkTheme: isDarkMode, // GTK+3
+		backgroundColor: '#fff',
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,


### PR DESCRIPTION
As described in the [Electron FAQ](https://github.com/electron/electron/blob/master/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do) and https://github.com/electron/electron/issues/10955, I tested that this fix restores subpixel rendering on Linux.