### PR TITLE
Improve a type annotation

### DIFF
--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -299,8 +299,7 @@ with this: https://static.xx.fbcdn.net/images/emoji.php/v9/z27/2/32/1f600.png
                                                  (see here) ^
 */
 export async function process(url: string): Promise<Response> {
-	// TODO: Remove the `any` here.
-	const emojiStyle = config.get('emojiStyle') as any;
+	const emojiStyle = config.get('emojiStyle') as EmojiStyle;
 	const emojiSetCode = codeForEmojiStyle(emojiStyle);
 
 	// The character code is the filename without the extension.


### PR DESCRIPTION
Very minor fix, but should address one "TODO" marking. In my testing (on Linux), I was able to switch emoji types with no errors/warnings.