### PR TITLE
Show restart dialog on the current window

### DIFF
--- a/source/util.ts
+++ b/source/util.ts
@@ -26,16 +26,19 @@ export async function sendBackgroundAction<T, TReturn>(action: string, args?: T)
 }
 
 export function showRestartDialog(message: string): void {
-	const buttonIndex = dialog.showMessageBoxSync({
-		message,
-		detail: 'Do you want to restart the app now?',
-		buttons: [
-			'Restart',
-			'Ignore'
-		],
-		defaultId: 0,
-		cancelId: 1
-	});
+	const buttonIndex = dialog.showMessageBoxSync(
+		getWindow(),
+		{
+			message,
+			detail: 'Do you want to restart the app now?',
+			buttons: [
+				'Restart',
+				'Ignore'
+			],
+			defaultId: 0,
+			cancelId: 1
+		}
+	);
 
 	if (buttonIndex === 0) {
 		app.relaunch();


### PR DESCRIPTION
Like https://github.com/sindresorhus/electron-util/pull/47, this change puts the Restart Dialog on top of the current window.