### PR TITLE
Disable ESLint max-params for async arrow function

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -508,6 +508,7 @@ function createMainWindow(): BrowserWindow {
 		}
 	});
 
+	// eslint-disable-next-line max-params
 	webContents.on('new-window', async (event: Event, url, frameName, _disposition, options) => {
 		event.preventDefault();
 


### PR DESCRIPTION
Disables the warning for more than 4 parameters in an async arrow function, despite Electron using one with 8 parameters in https://www.electronjs.org/docs/api/web-contents

```javascript
myBrowserWindow.webContents.on('new-window', (event, url, frameName, disposition, options, additionalFeatures, referrer, postBody) => {
}
```