### PR TITLE
Hide banner for Messenger App for Windows

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -84,8 +84,13 @@ html.private-mode [role=main] .d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.a8c3
 	filter: blur(5px);
 }
 
-/* Hide the "Messenger App for Windows" banner */
+/* Hide the "Messenger App for Windows" banner in chat list */
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.s9xz0pwp.c4m0enpj.rl78xhln.srn514ro.sn0e7ne5.f6rbj1fe.l3ldwz01 {
+	display: none;
+}
+/* Hide the "Messenger for Windows" menu item and separator in Messenger settings */
+.tojvnm2t.a6sixzi8.k5wvi7nf.q3lfd5jv.pk4s997a.bipmatt0.cebpdrjk.qowsmv63.owwhemhu.dp1hu0rb.dhp61c6y.l9j0dhe7.iyyx5f41.a8s20v7p > hr:nth-of-type(4),
+.tojvnm2t.a6sixzi8.k5wvi7nf.q3lfd5jv.pk4s997a.bipmatt0.cebpdrjk.qowsmv63.owwhemhu.dp1hu0rb.dhp61c6y.l9j0dhe7.iyyx5f41.a8s20v7p > a:nth-of-type(6) {
 	display: none;
 }
 

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -85,12 +85,12 @@ html.private-mode [role=main] .d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.a8c3
 }
 
 /* Hide the "Messenger App for Windows" banner in chat list */
-.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.s9xz0pwp.c4m0enpj.rl78xhln.srn514ro.sn0e7ne5.f6rbj1fe.l3ldwz01 {
+.os-win32 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.s9xz0pwp.c4m0enpj.rl78xhln.srn514ro.sn0e7ne5.f6rbj1fe.l3ldwz01 {
 	display: none;
 }
 /* Hide the "Messenger for Windows" menu item and separator in Messenger settings */
-.tojvnm2t.a6sixzi8.k5wvi7nf.q3lfd5jv.pk4s997a.bipmatt0.cebpdrjk.qowsmv63.owwhemhu.dp1hu0rb.dhp61c6y.l9j0dhe7.iyyx5f41.a8s20v7p > hr:nth-of-type(4),
-.tojvnm2t.a6sixzi8.k5wvi7nf.q3lfd5jv.pk4s997a.bipmatt0.cebpdrjk.qowsmv63.owwhemhu.dp1hu0rb.dhp61c6y.l9j0dhe7.iyyx5f41.a8s20v7p > a:nth-of-type(6) {
+.os-win32 .tojvnm2t.a6sixzi8.k5wvi7nf.q3lfd5jv.pk4s997a.bipmatt0.cebpdrjk.qowsmv63.owwhemhu.dp1hu0rb.dhp61c6y.l9j0dhe7.iyyx5f41.a8s20v7p > hr:nth-of-type(4),
+.os-win32 .tojvnm2t.a6sixzi8.k5wvi7nf.q3lfd5jv.pk4s997a.bipmatt0.cebpdrjk.qowsmv63.owwhemhu.dp1hu0rb.dhp61c6y.l9j0dhe7.iyyx5f41.a8s20v7p > a:nth-of-type(6) {
 	display: none;
 }
 

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -84,6 +84,11 @@ html.private-mode [role=main] .d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.a8c3
 	filter: blur(5px);
 }
 
+/* Hide the "Messenger App for Windows" banner */
+.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.s9xz0pwp.c4m0enpj.rl78xhln.srn514ro.sn0e7ne5.f6rbj1fe.l3ldwz01 {
+	display: none;
+}
+
 /* Dragable region for macOS */
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.jei6r52m.wkznzc2l.n851cfcs.dhix69tm.ahb00how,
 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.hv4rvrfc.dati1w0a.f10w8fjw.pybr56ya.b5q2rw42.lq239pai.mysgfdmx.hddg9phg {


### PR DESCRIPTION
This fully eliminates the banner advertising the Messenger App for Windows. Perhaps we may not want to remove it entirely, but if someone is using Caprine, they probably want to stick with it.

Regardless, the banner gets a bit mangled with the narrow sidebar:
![image](https://user-images.githubusercontent.com/17033543/116121116-4e0d6680-a68e-11eb-830c-047480ef56de.png)

The wide sidebar shows this correctly: 
![image](https://user-images.githubusercontent.com/17033543/116121243-6ed5bc00-a68e-11eb-8b6b-e449ac42bb23.png)

Another possibility would be to remove the banner when the sidebar is narrow, but keep it when the sidebar is wide?

