### PR TITLE
Refactor GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,31 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm test
-      - run: npm run dist
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+  build:
+    needs: [test]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - uses: c-hive/gha-npm-cache@v1
+      - uses: samuelmeuli/action-snapcraft@v1
+        if: startsWith(matrix.os, 'ubuntu')
+        with:
+          snapcraft_token: ${{ secrets.snapcraft_token }}
+      - uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release: true
+          mac_certs: ${{ secrets.CSC_LINK }}
+          mac_certs_password: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -19,10 +19,8 @@
 		"lint": "tsc && xo && stylelint \"css/*.css\"",
 		"test": "npm run lint",
 		"start": "tsc && electron .",
-		"pack": "tsc && electron-builder --dir",
-		"dist": "tsc && electron-builder --macos --linux --windows --publish=always",
-		"release": "np && npm run publish-snap",
-		"publish-snap": "del dist && tsc && electron-builder --linux && snapcraft push --release=stable dist/*.snap"
+		"build": "tsc",
+		"release": "np"
 	},
 	"dependencies": {
 		"@sindresorhus/do-not-disturb": "^1.1.0",


### PR DESCRIPTION
So far main workflow would test and build Caprine for Linux, macOS and Windows on macOS platform which would result in bad checksums. Also tests sometimes break for no reason at all.

The main difference here is that build and test jobs are split and build process is run on respecting platform for each package. This doesn't break the checksum. This can be seen in action in [playground](https://github.com/dusansimic/caprine-playground) repo.

Aditionally, everything is published automatically, including the snap package.

Closes: #1563 
Closes: #1554 
Closes: #1163 