### PR TITLE
Apply dark mode to all new nodes

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -409,15 +409,15 @@ async function observeDarkMode(): Promise<void> {
 	/* Added nodes (dialogs, etc.) */
 	const observerNew = new MutationObserver((records: MutationRecord[]) => {
 		const nodeRecords = records.filter(record => record.addedNodes.length > 0);
-		nodeRecords.forEach(nodeRecord => {
-			nodeRecord.addedNodes.forEach(newNode => {
+		for (const nodeRecord of nodeRecords) {
+			for (const newNode of nodeRecord.addedNodes) {
 				const {classList} = (newNode as HTMLElement);
 				const isLight = classList.contains('light-mode') || classList.contains('__fb-light-mode');
 				if (api.nativeTheme.shouldUseDarkColors === isLight) {
 					setDarkModeElement(newNode as HTMLElement);
 				}
-			});
-		});
+			}
+		}
 	});
 
 	observerNew.observe(document, {subtree: true, childList: true, attributes: true, attributeFilter: ['addedNodes']});

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -420,7 +420,16 @@ async function observeDarkMode(): Promise<void> {
 		}
 	});
 
-	observerNew.observe(document, {subtree: true, childList: true, attributes: true, attributeFilter: ['addedNodes']});
+	/* Observe only elements where new nodes may need dark mode */
+	const menuElements = await elementReady<HTMLElement>('html > body > div:nth-of-type(1) > div > div:nth-of-type(1) > div > div:nth-of-type(3) > div', {stopOnDomReady: false});
+	if (menuElements) {
+		observerNew.observe(menuElements, {childList: true});
+	}
+
+	const modalElements = await elementReady<HTMLElement>('html > body > div:nth-of-type(1) > div > div:nth-of-type(1) > div > div:nth-of-type(2) > div > div > div:nth-of-type(2) > div', {stopOnDomReady: false});
+	if (modalElements) {
+		observerNew.observe(modalElements, {childList: true});
+	}
 }
 
 function setPrivateMode(isNewDesign: boolean): void {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -421,12 +421,13 @@ async function observeDarkMode(): Promise<void> {
 	});
 
 	/* Observe only elements where new nodes may need dark mode */
-	const menuElements = await elementReady<HTMLElement>('div[class="rq0escxv l9j0dhe7 du4w35lb"] > div:nth-of-type(3) > div', {stopOnDomReady: false});
+	const menuElements = await elementReady<HTMLElement>('.j83agx80.cbu4d94t.l9j0dhe7.jgljxmt5.be9z9djy > div:nth-of-type(2) > div', {stopOnDomReady: false});
 	if (menuElements) {
 		observerNew.observe(menuElements, {childList: true});
 	}
 
-	const modalElements = await elementReady<HTMLElement>('.j83agx80.cbu4d94t.l9j0dhe7.jgljxmt5.be9z9djy > div:nth-of-type(2) > div', {stopOnDomReady: false});
+	// Attribute notation needed here to guarantee exact (not partial) match.
+	const modalElements = await elementReady<HTMLElement>('div[class="rq0escxv l9j0dhe7 du4w35lb"] > div:nth-of-type(3) > div', {stopOnDomReady: false});
 	if (modalElements) {
 		observerNew.observe(modalElements, {childList: true});
 	}

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -421,12 +421,12 @@ async function observeDarkMode(): Promise<void> {
 	});
 
 	/* Observe only elements where new nodes may need dark mode */
-	const menuElements = await elementReady<HTMLElement>('html > body > div:nth-of-type(1) > div > div:nth-of-type(1) > div > div:nth-of-type(3) > div', {stopOnDomReady: false});
+	const menuElements = await elementReady<HTMLElement>('div[class="rq0escxv l9j0dhe7 du4w35lb"] > div:nth-of-type(3) > div', {stopOnDomReady: false});
 	if (menuElements) {
 		observerNew.observe(menuElements, {childList: true});
 	}
 
-	const modalElements = await elementReady<HTMLElement>('html > body > div:nth-of-type(1) > div > div:nth-of-type(1) > div > div:nth-of-type(2) > div > div > div:nth-of-type(2) > div', {stopOnDomReady: false});
+	const modalElements = await elementReady<HTMLElement>('.j83agx80.cbu4d94t.l9j0dhe7.jgljxmt5.be9z9djy > div:nth-of-type(2) > div', {stopOnDomReady: false});
 	if (modalElements) {
 		observerNew.observe(modalElements, {childList: true});
 	}


### PR DESCRIPTION
Even if dark mode was set, new nodes (dialogs, etc.) would appear with the `__fb-light-mode` tag, which breaks the theming. I've set up an observer for added nodes and only change ones that have some sort of light mode tag.

This may not be the best or most efficient way to do this, but it seems to apply to most dialogs that I was able to find: Preferences dropdown and overlay, emoji picker, etc.