### PR TITLE
Check that CSS file exists (for new design)

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -454,7 +454,9 @@ function createMainWindow(): BrowserWindow {
 			path.join(__dirname, '..', 'css');
 
 		for (const file of files) {
-			webContents.insertCSS(readFileSync(path.join(cssPath, file), 'utf8'));
+			if (existsSync(file)) {
+				webContents.insertCSS(readFileSync(path.join(cssPath, file), 'utf8'));
+			}
 		}
 
 		if (config.get('useWorkChat')) {


### PR DESCRIPTION
The linting applied in #1628 removed some empty files in `css/new-design`. We do a simple `existsSync()` to ensure that the file exists before applying its CSS.