### PR TITLE
Fix preferences selector

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -9,7 +9,7 @@ html.hide-dropdowns [role='menu'].l9j0dhe7.swg4t2nn {
 }
 
 /* A utility class for temporarily hiding preferences window */
-html.hide-preferences-window [data-pagelet='root'] > div > div:last-child {
+html.hide-preferences-window div[class='rq0escxv l9j0dhe7 du4w35lb'] > div:nth-of-type(3) > div > div {
 	display: none;
 }
 

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -696,9 +696,9 @@ async function closePreferences(isNewDesign: boolean): Promise<void> {
 			}
 		});
 
-		const preferencesOverlay = document.querySelector('[data-pagelet=root] > div > div:last-child')!;
+		const preferencesOverlay = document.querySelector('div[class="rq0escxv l9j0dhe7 du4w35lb"] > div:nth-of-type(3) > div')!;
 
-		return preferencesOverlayObserver.observe(preferencesOverlay, {childList: true, subtree: true});
+		return preferencesOverlayObserver.observe(preferencesOverlay, {childList: true});
 	}
 
 	const doneButton = document.querySelector<HTMLElement>('._3quh._30yy._2t_._5ixy')!;


### PR DESCRIPTION
Going along with the changes in selectors in #1629, the Preferences overlay was not being selected properly (and would raise an `UnhandledPromiseRejectionWarning`). In addition, the `subtree: true` can be removed from the `observe()` function.