### PR TITLE
Use full path to check that CSS file exists

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -454,7 +454,7 @@ function createMainWindow(): BrowserWindow {
 			path.join(__dirname, '..', 'css');
 
 		for (const file of files) {
-			if (existsSync(file)) {
+			if (existsSync(path.join(cssPath, file))) {
 				webContents.insertCSS(readFileSync(path.join(cssPath, file), 'utf8'));
 			}
 		}

--- a/source/index.ts
+++ b/source/index.ts
@@ -459,7 +459,7 @@ function createMainWindow(): BrowserWindow {
 			}
 		}
 
-		if (config.get('useWorkChat')) {
+		if (config.get('useWorkChat') && existsSync(path.join(cssPath, 'workchat.css'))) {
 			webContents.insertCSS(
 				readFileSync(path.join(cssPath, 'workchat.css'), 'utf8')
 			);


### PR DESCRIPTION
The change in #1630 did not check for the *full* path. This was causing none of the CSS files to be read, since they don't exist in the `source/` directory.

Also, there was not a check for the `workchat.css` case. Now all of the `insertCSS` blocks have the same structure.