### PR TITLE
Combine system appearance and dark mode settings

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -370,20 +370,20 @@ ipc.answerMain('reload', () => {
 	location.reload();
 });
 
-function setThemeMode(): void {
+function setTheme(): void {
 	api.nativeTheme.themeSource = config.get('theme');
-	setThemeModeElement(document.documentElement);
+	setThemeElement(document.documentElement);
 	updateVibrancy();
 }
 
-function setThemeModeElement(element: HTMLElement): void {
+function setThemeElement(element: HTMLElement): void {
 	element.classList.toggle('dark-mode', api.nativeTheme.shouldUseDarkColors);
 	element.classList.toggle('light-mode', !api.nativeTheme.shouldUseDarkColors);
 	element.classList.toggle('__fb-dark-mode', api.nativeTheme.shouldUseDarkColors);
 	element.classList.toggle('__fb-light-mode', !api.nativeTheme.shouldUseDarkColors);
 }
 
-async function observeThemeMode(): Promise<void> {
+async function observeTheme(): Promise<void> {
 	/* Main document's class list */
 	const observer = new MutationObserver((records: MutationRecord[]) => {
 		// Find records that had class attribute changed
@@ -395,7 +395,7 @@ async function observeThemeMode(): Promise<void> {
 		});
 		// If config and class list don't match, update class list
 		if (api.nativeTheme.shouldUseDarkColors !== isDark) {
-			setThemeMode();
+			setTheme();
 		}
 	});
 
@@ -409,7 +409,7 @@ async function observeThemeMode(): Promise<void> {
 				const {classList} = (newNode as HTMLElement);
 				const isLight = classList.contains('light-mode') || classList.contains('__fb-light-mode');
 				if (api.nativeTheme.shouldUseDarkColors === isLight) {
-					setThemeModeElement(newNode as HTMLElement);
+					setThemeElement(newNode as HTMLElement);
 				}
 			}
 		}
@@ -509,7 +509,7 @@ ipc.answerMain('update-sidebar', () => {
 	updateSidebar();
 });
 
-ipc.answerMain('set-theme-mode', setThemeMode);
+ipc.answerMain('set-theme', setTheme);
 
 ipc.answerMain('set-private-mode', setPrivateMode);
 
@@ -812,9 +812,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 	updateSidebar();
 
 	// Activate Dark Mode if it was set before quitting
-	setThemeMode();
+	setTheme();
 	// Observe for dark mode changes
-	observeThemeMode();
+	observeTheme();
 
 	// Activate Private Mode if it was set before quitting
 	setPrivateMode(newDesign);

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -370,25 +370,20 @@ ipc.answerMain('reload', () => {
 	location.reload();
 });
 
-function setDarkMode(): void {
-	setDarkModeElement(document.documentElement);
+function setThemeMode(): void {
+	api.nativeTheme.themeSource = config.get('theme');
+	setThemeModeElement(document.documentElement);
 	updateVibrancy();
 }
 
-function setDarkModeElement(element: HTMLElement): void {
-	if (is.macos && config.get('followSystemAppearance')) {
-		api.nativeTheme.themeSource = 'system';
-	} else {
-		api.nativeTheme.themeSource = config.get('darkMode') ? 'dark' : 'light';
-	}
-
+function setThemeModeElement(element: HTMLElement): void {
 	element.classList.toggle('dark-mode', api.nativeTheme.shouldUseDarkColors);
 	element.classList.toggle('light-mode', !api.nativeTheme.shouldUseDarkColors);
 	element.classList.toggle('__fb-dark-mode', api.nativeTheme.shouldUseDarkColors);
 	element.classList.toggle('__fb-light-mode', !api.nativeTheme.shouldUseDarkColors);
 }
 
-async function observeDarkMode(): Promise<void> {
+async function observeThemeMode(): Promise<void> {
 	/* Main document's class list */
 	const observer = new MutationObserver((records: MutationRecord[]) => {
 		// Find records that had class attribute changed
@@ -400,7 +395,7 @@ async function observeDarkMode(): Promise<void> {
 		});
 		// If config and class list don't match, update class list
 		if (api.nativeTheme.shouldUseDarkColors !== isDark) {
-			setDarkMode();
+			setThemeMode();
 		}
 	});
 
@@ -414,7 +409,7 @@ async function observeDarkMode(): Promise<void> {
 				const {classList} = (newNode as HTMLElement);
 				const isLight = classList.contains('light-mode') || classList.contains('__fb-light-mode');
 				if (api.nativeTheme.shouldUseDarkColors === isLight) {
-					setDarkModeElement(newNode as HTMLElement);
+					setThemeModeElement(newNode as HTMLElement);
 				}
 			}
 		}
@@ -514,7 +509,7 @@ ipc.answerMain('update-sidebar', () => {
 	updateSidebar();
 });
 
-ipc.answerMain('set-dark-mode', setDarkMode);
+ipc.answerMain('set-theme-mode', setThemeMode);
 
 ipc.answerMain('set-private-mode', setPrivateMode);
 
@@ -817,9 +812,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 	updateSidebar();
 
 	// Activate Dark Mode if it was set before quitting
-	setDarkMode();
+	setThemeMode();
 	// Observe for dark mode changes
-	observeDarkMode();
+	observeThemeMode();
 
 	// Activate Private Mode if it was set before quitting
 	setPrivateMode(newDesign);

--- a/source/config.ts
+++ b/source/config.ts
@@ -2,8 +2,7 @@ import Store = require('electron-store');
 import {is} from 'electron-util';
 
 type StoreType = {
-	followSystemAppearance: boolean;
-	darkMode: boolean;
+	theme: 'system' | 'light' | 'dark';
 	privateMode: boolean;
 	showPrivateModePrompt: boolean;
 	vibrancy: 'none' | 'sidebar' | 'full';
@@ -45,13 +44,10 @@ type StoreType = {
 };
 
 const schema: Store.Schema<StoreType> = {
-	followSystemAppearance: {
-		type: 'boolean',
-		default: true
-	},
-	darkMode: {
-		type: 'boolean',
-		default: false
+	theme: {
+		type: 'string',
+		enum: ['system', 'light', 'dark'],
+		default: 'system'
 	},
 	privateMode: {
 		type: 'boolean',

--- a/source/index.ts
+++ b/source/index.ts
@@ -274,7 +274,6 @@ function setNotificationsMute(status: boolean): void {
 
 function createMainWindow(): BrowserWindow {
 	const lastWindowState = config.get('lastWindowState');
-	const isDarkMode = config.get('darkMode');
 
 	// Messenger or Work Chat
 	const mainURL = config.get('useWorkChat') ?
@@ -294,7 +293,6 @@ function createMainWindow(): BrowserWindow {
 		alwaysOnTop: config.get('alwaysOnTop'),
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
-		darkTheme: isDarkMode, // GTK+3
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,
@@ -312,7 +310,7 @@ function createMainWindow(): BrowserWindow {
 	darkMode.onChange(() => {
 		if (darkMode.isEnabled !== previousDarkMode) {
 			previousDarkMode = darkMode.isEnabled;
-			win.webContents.send('set-dark-mode');
+			win.webContents.send('set-theme-mode');
 		}
 	});
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -311,7 +311,7 @@ function createMainWindow(): BrowserWindow {
 	darkMode.onChange(() => {
 		if (darkMode.isEnabled !== previousDarkMode) {
 			previousDarkMode = darkMode.isEnabled;
-			win.webContents.send('set-theme-mode');
+			win.webContents.send('set-theme');
 		}
 	});
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -293,7 +293,6 @@ function createMainWindow(): BrowserWindow {
 		alwaysOnTop: config.get('alwaysOnTop'),
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
-		darkTheme: config.get('theme') === 'dark', // GTK+3
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -274,7 +274,6 @@ function setNotificationsMute(status: boolean): void {
 
 function createMainWindow(): BrowserWindow {
 	const lastWindowState = config.get('lastWindowState');
-	const isDarkMode = config.get('theme') === 'system' ? undefined : config.get('theme') === 'dark';
 
 	// Messenger or Work Chat
 	const mainURL = config.get('useWorkChat') ?
@@ -294,7 +293,7 @@ function createMainWindow(): BrowserWindow {
 		alwaysOnTop: config.get('alwaysOnTop'),
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
-		darkTheme: isDarkMode, // GTK+3
+		darkTheme: config.get('theme') === 'dark', // GTK+3
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,

--- a/source/index.ts
+++ b/source/index.ts
@@ -274,6 +274,7 @@ function setNotificationsMute(status: boolean): void {
 
 function createMainWindow(): BrowserWindow {
 	const lastWindowState = config.get('lastWindowState');
+	const isDarkMode = config.get('theme') === 'system' ? undefined : config.get('theme') === 'dark';
 
 	// Messenger or Work Chat
 	const mainURL = config.get('useWorkChat') ?
@@ -293,6 +294,7 @@ function createMainWindow(): BrowserWindow {
 		alwaysOnTop: config.get('alwaysOnTop'),
 		titleBarStyle: 'hiddenInset',
 		autoHideMenuBar: config.get('autoHideMenuBar'),
+		darkTheme: isDarkMode, // GTK+3
 		webPreferences: {
 			preload: path.join(__dirname, 'browser.js'),
 			nativeWindowOpen: true,

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -100,9 +100,6 @@ export default async function updateMenu({isNewDesign}: INewDesign): Promise<Men
 			}
 		},
 		{
-			type: 'separator'
-		},
-		{
 			label: 'Light Mode',
 			type: 'checkbox',
 			checked: config.get('theme') === 'light',

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -95,7 +95,7 @@ export default async function updateMenu({isNewDesign}: INewDesign): Promise<Men
 			checked: config.get('theme') === 'system',
 			async click() {
 				config.set('theme', 'system');
-				sendAction('set-theme-mode');
+				sendAction('set-theme');
 				await updateMenu({isNewDesign});
 			}
 		},
@@ -105,7 +105,7 @@ export default async function updateMenu({isNewDesign}: INewDesign): Promise<Men
 			checked: config.get('theme') === 'light',
 			async click() {
 				config.set('theme', 'light');
-				sendAction('set-theme-mode');
+				sendAction('set-theme');
 				await updateMenu({isNewDesign});
 			}
 		},
@@ -115,7 +115,7 @@ export default async function updateMenu({isNewDesign}: INewDesign): Promise<Men
 			checked: config.get('theme') === 'dark',
 			async click() {
 				config.set('theme', 'dark');
-				sendAction('set-theme-mode');
+				sendAction('set-theme');
 				await updateMenu({isNewDesign});
 			}
 		}

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -88,6 +88,42 @@ export default async function updateMenu({isNewDesign}: INewDesign): Promise<Men
 		}
 	];
 
+	const themeSubmenu: MenuItemConstructorOptions[] = [
+		{
+			label: 'Follow System Appearance',
+			type: 'checkbox',
+			checked: config.get('theme') === 'system',
+			async click() {
+				config.set('theme', 'system');
+				sendAction('set-theme-mode');
+				await updateMenu({isNewDesign});
+			}
+		},
+		{
+			type: 'separator'
+		},
+		{
+			label: 'Light Mode',
+			type: 'checkbox',
+			checked: config.get('theme') === 'light',
+			async click() {
+				config.set('theme', 'light');
+				sendAction('set-theme-mode');
+				await updateMenu({isNewDesign});
+			}
+		},
+		{
+			label: 'Dark Mode',
+			type: 'checkbox',
+			checked: config.get('theme') === 'dark',
+			async click() {
+				config.set('theme', 'dark');
+				sendAction('set-theme-mode');
+				await updateMenu({isNewDesign});
+			}
+		}
+	];
+
 	const sidebarSubmenu: MenuItemConstructorOptions[] = [
 		{
 			label: 'Adaptive Sidebar',
@@ -408,27 +444,8 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			type: 'separator'
 		},
 		{
-			label: 'Follow System Appearance',
-			type: 'checkbox',
-			visible: is.macos,
-			checked: config.get('followSystemAppearance'),
-			async click() {
-				config.set('followSystemAppearance', !config.get('followSystemAppearance'));
-				sendAction('set-dark-mode');
-				await updateMenu({isNewDesign});
-			}
-		},
-		{
-			label: 'Dark Mode',
-			id: 'darkMode',
-			type: 'checkbox',
-			checked: config.get('darkMode'),
-			enabled: !is.macos || !config.get('followSystemAppearance'),
-			accelerator: 'CommandOrControl+D',
-			click() {
-				config.set('darkMode', !config.get('darkMode'));
-				sendAction('set-dark-mode');
-			}
+			label: 'Theme',
+			submenu: themeSubmenu
 		},
 		{
 			label: 'Vibrancy',


### PR DESCRIPTION
The `api.nativeTheme` should work for non-MacOS platforms. This PR combines the `followSystemAppearance` and `darkMode` settings into a `'theme'` configuration setting, which mirrors the `api.nativeTheme.themeSource` variable. However, setting the `'dark'` or `'light'` mode should override the system settings.

I'm not sure if removing the `darkTheme`, which is supposed to force dark mode with _some_ GTK+3 environments, is okay. It could cause some issues with those environments that rely on this configuration.

The theme only updates when you click on the window, but I don't think it should be constantly checking while Caprine is in the background.

Tested on:
- Windows 10, build 19042
- Linux Mint 20.1, Cinnamon DE