### PR TITLE
Use a dark scrollbar in conversation in dark mode

### DIFF
--- a/css/new-design/dark-mode.css
+++ b/css/new-design/dark-mode.css
@@ -40,6 +40,11 @@
 	color: var(--primary-text);
 }
 
+/* Conversation: Scrollbar */
+.buofh1pr.j83agx80.eg9m0zos.ni8dbmo4.cbu4d94t.gok29vw1 {
+	color-scheme: dark;
+}
+
 /* Removing top gap */
 /* TODO: Remove when fixed by fb */
 html.dark-mode .be9z9djy {

--- a/source/index.ts
+++ b/source/index.ts
@@ -301,7 +301,8 @@ function createMainWindow(): BrowserWindow {
 			contextIsolation: true,
 			spellcheck: config.get('isSpellCheckerEnabled'),
 			plugins: true,
-			enableRemoteModule: true
+			enableRemoteModule: true,
+			enableBlinkFeatures: 'CSSColorSchemeUARendering'
 		}
 	});
 


### PR DESCRIPTION
This is technically using an "experimental" flag (`enableBlinkFeatures: 'CSSColorSchemeUARendering'`), but as far as I can tell, it only affects the scrollbar. Though there might be more ways to use the `color-scheme: dark;` in the CSS, but the current dark mode CSS doesn't appear to be affected when turning this setting on.