### PR TITLE
Fix preferences selector for removing hide-preferences-window class

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -10,7 +10,7 @@ import {INewDesign, IToggleMuteNotifications, IToggleSounds} from './types';
 const selectedConversationSelector = '._5l-3._1ht1._1ht2';
 const selectedConversationNewDesign = '[role=navigation] [role=grid] [role=row] [role=gridcell] [role=link][aria-current]';
 const preferencesSelector = '._10._4ebx.uiLayer._4-hy';
-const preferencesSelectorNewDesign = '[aria-label=Preferences]';
+const preferencesSelectorNewDesign = 'div[class="rq0escxv l9j0dhe7 du4w35lb"] > div:nth-of-type(3) > div';
 const messengerSoundsSelector = `${preferencesSelector} ._374d ._6bkz`;
 const conversationMenuSelector = '.uiLayer:not(.hidden_elem) [role=menu]';
 const conversationMenuSelectorNewDesign = '[role=menu].l9j0dhe7.swg4t2nn';
@@ -422,7 +422,7 @@ async function observeTheme(): Promise<void> {
 	}
 
 	// Attribute notation needed here to guarantee exact (not partial) match.
-	const modalElements = await elementReady<HTMLElement>('div[class="rq0escxv l9j0dhe7 du4w35lb"] > div:nth-of-type(3) > div', {stopOnDomReady: false});
+	const modalElements = await elementReady<HTMLElement>(preferencesSelectorNewDesign, {stopOnDomReady: false});
 	if (modalElements) {
 		observerNew.observe(modalElements, {childList: true});
 	}


### PR DESCRIPTION
Following along with #1632, this removes a locale-specific `aria-label` when deciding on whether to remove the `hide-preferences-window` class.

These should probably be abstracted to the `source/browser/selectors.ts` file instead of defining these selectors in the header of `source/browser.ts`.

Fixes #1645,
Fixes #1579.