### PR TITLE
[WIP] Sidebar Modes for New Design

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -133,3 +133,24 @@ html.sidebar-hidden .o36gj0jk.g0mhvs5p {
 	width: 0;
 	height: 0;
 }
+
+/* Narrow: Hide conversation previews */
+html.sidebar-force-narrow .gs1a9yip.ow4ym5g4.auili1gw.rq0escxv.j83agx80.cbu4d94t.buofh1pr.g5gj957u.i1fnvgqd.oygrvhab.cxmmr5t8.hcukyx3x.kvgmc6g5.tgvbjcpo.hpfvmrgz.rz4wbd8a.a8nywdso.l9j0dhe7.du4w35lb.rj1gh0hx.pybr56ya.f10w8fjw {
+	visibility: hidden;
+}
+/* Narrow: Width of search bar */
+html.sidebar-force-narrow .oajrlxb2.rq0escxv.f1sip0of.hidtqoto.e70eycc3.lzcic4wl.hzawbc8m.ijkhr0an.aaoq3grb.sgqwj88q.b3i9ofy5.oo9gr5id.b1f16np4.hdh3q7d8.dwo3fsh8.qu0x051f.esr5mh6w.e9989ue4.r7d6kgcz.br7hx15l.h2jyy9rg.n3ddgdk9.owxd89k7.ihxqhq3m.jq4qci2q.k4urcfbm.iu8raji3.tv7at329.l60d2q6s.d1544ag0.hwnh5xvq.fjf4s8hc.aj8hi1zk.r4fl40cc.kd8v7px7.m07ooulj.mzan44vs {
+	width: 68px;
+}
+/* Narrow: Conversation list header */
+html.sidebar-force-narrow .ahb00how {
+	display: none;
+}
+/* Narrow: Width of conversation list */
+html.sidebar-force-narrow .g0mhvs5p {
+	width: 88px;
+}
+/* Narrow: Remove scrollbar from conversation list */
+html.sidebar-force-narrow .oj68ptkr.jk6sbkaj.kdgqqoy6.ihh4hy1g.qttc61fc.datstx6m.k4urcfbm {
+	visibility: hidden;
+}

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -154,3 +154,12 @@ html.sidebar-force-narrow .g0mhvs5p {
 html.sidebar-force-narrow .oj68ptkr.jk6sbkaj.kdgqqoy6.ihh4hy1g.qttc61fc.datstx6m.k4urcfbm {
 	visibility: hidden;
 }
+
+/* Wide: Width of conversation list */
+html.sidebar-force-wide .g0mhvs5p {
+	width: 360px;
+}
+/* Wide: Conversation list header */
+html.sidebar-force-wide .ahb00how {
+	display: flex;
+}

--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -122,3 +122,14 @@ html.private-mode [role='main'] .d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.a8
 		padding-top: 36px !important;
 	}
 }
+
+/* -- Sidebar views -- */
+
+/* Hidden: Hide sidebar */
+html.sidebar-hidden .o36gj0jk.g0mhvs5p {
+	visibility: hidden;
+	min-width: 0;
+	max-width: 0;
+	width: 0;
+	height: 0;
+}


### PR DESCRIPTION
I was able to properly create the "hidden" and "narrow" modes. The "wide" mode is currently a work in progress for the following reason (everything else works as expected). It seems that the design actually _removes_ the elements that contain the conversation previews. For the "narrow" mode, I used `visibility: hidden`, but going the opposite direction is not as easy.

![image](https://user-images.githubusercontent.com/17033543/120906096-9ff9c280-c624-11eb-9482-5a117c803fd5.png)


Any advice for how to keep these previews with a wide sidebar? I'm thinking that it cannot be a CSS-only solution, unfortunately…

[One weird quirk with their CSS: Some changes are triggered with `max-width: 900px` and some are triggered with `max-width: 899 px`. This means that if you set the width to exactly 900 px, you'll get a narrow sidebar, but the conversation previews are there (but you can only see half of the first letter or so).]