### PR TITLE
Eliminate check for `darkMode` setting

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -826,7 +826,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Prevent flash of white on startup when in dark mode
 	// TODO: find a CSS-only solution
-	if (!is.macos && config.get('darkMode')) {
+	if (!is.macos && api.nativeTheme.shouldUseDarkColors) {
 		document.documentElement.style.backgroundColor = '#1e1e1e';
 	}
 


### PR DESCRIPTION
This check was missed in #1637. However, this might not even be necessary any more? I did some testing with Dark, Light, and System Appearance, and there were no flashes of incorrect colors with this section commented out.