### PR TITLE
Use getIconPath() in tray.setBadge()

### DIFF
--- a/source/tray.ts
+++ b/source/tray.ts
@@ -129,9 +129,7 @@ export default {
 			return;
 		}
 
-		const icon = shouldDisplayUnread ? 'IconTrayUnread.png' : 'IconTray.png';
-		const iconPath = path.join(__dirname, '..', 'static', icon);
-		tray.setImage(iconPath);
+		tray.setImage(getIconPath(shouldDisplayUnread));
 	}
 };
 


### PR DESCRIPTION
The function `getIconPath()` exists for a reason, so this implements it in the `tray.setBadge()` function.