### PR TITLE
Migrate `darkMode` settings in config file

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -232,9 +232,28 @@ function updateSidebarSetting(store: Store<StoreType>): void {
 	}
 }
 
+function updateThemeSetting(store: Store<StoreType>): void {
+	if (store.get('followSystemAppearance')) {
+		store.set('theme', 'system');
+		// @ts-expect-error
+		store.delete('followSystemAppearance');
+	} else if (store.get('darkMode') === true) {
+		store.set('theme', 'dark');
+		// @ts-expect-error
+		store.delete('darkMode');
+	} else if (store.get('darkMode') === false) {
+		store.set('theme', 'light');
+		// @ts-expect-error
+		store.delete('darkMode');
+	} else if (!store.has('theme')) {
+		store.set('theme', 'system');
+	}
+}
+
 function migrate(store: Store<StoreType>): void {
 	updateVibrancySetting(store);
 	updateSidebarSetting(store);
+	updateThemeSetting(store);
 }
 
 const store = new Store<StoreType>({schema});

--- a/source/config.ts
+++ b/source/config.ts
@@ -233,20 +233,25 @@ function updateSidebarSetting(store: Store<StoreType>): void {
 }
 
 function updateThemeSetting(store: Store<StoreType>): void {
-	if (store.get('followSystemAppearance')) {
+	const darkMode = store.get('darkMode');
+	const followSystemAppearance = store.get('followSystemAppearance');
+
+	if (is.macos && followSystemAppearance) {
 		store.set('theme', 'system');
-		// @ts-expect-error
-		store.delete('followSystemAppearance');
-	} else if (store.get('darkMode') === true) {
-		store.set('theme', 'dark');
-		// @ts-expect-error
-		store.delete('darkMode');
-	} else if (store.get('darkMode') === false) {
-		store.set('theme', 'light');
-		// @ts-expect-error
-		store.delete('darkMode');
+	} else if (typeof darkMode !== 'undefined') {
+		store.set('theme', darkMode ? 'dark' : 'light');
 	} else if (!store.has('theme')) {
 		store.set('theme', 'system');
+	}
+
+	if (typeof darkMode !== 'undefined') {
+		// @ts-expect-error
+		store.delete('darkMode');
+	}
+
+	if (typeof followSystemAppearance !== 'undefined') {
+		// @ts-expect-error
+		store.delete('followSystemAppearance');
 	}
 }
 


### PR DESCRIPTION
The `darkMode` setting was replaced by `theme`, but the configuration file was not updated accordingly.

I believe that `'system'` should be the default, but I wouldn't want to force it on everyone who may have had `darkMode` set for specific reasons. This migration honors any previous configuration with `darkMode`.