### PR TITLE
Add option to copy image address

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -39,6 +39,7 @@ electronDebug({
 
 electronDl();
 electronContextMenu({
+	showCopyImageAddress: true,
 	prepend: defaultActions => {
 		/*
 		TODO: Use menu option or use replacement of options (https://github.com/sindresorhus/electron-context-menu/issues/70)


### PR DESCRIPTION
Image addresses do not have tracking information on them, so there's no need to apply `stripTrackingFromUrl` for these links.

Fixes #1662.