### PR TITLE
Stop checking for new design on DOM ready

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -982,7 +982,7 @@ ipc.answerMain('notification-reply-callback', async (data: any) => {
 });
 
 export async function isNewDesign(): Promise<boolean> {
-	return Boolean(await elementReady('._9dls', {stopOnDomReady: false}));
+	return Boolean(await elementReady('._9dls', {stopOnDomReady: true}));
 }
 
 ipc.answerMain<undefined, boolean>('check-new-ui', async () => {


### PR DESCRIPTION
This stops the checking for the new design on the DOM ready event. This is necessary to continue the code in `source/index.ts` for the old design, and also for when the user is not already logged in (when the "new design" class does not exist yet). After login, the checks will happen again for the new design. It is unlikely that Messenger would change designs after the DOM ready event.

Fixes #1613.