### PR TITLE
Fix received messages color in dark mode

### DIFF
--- a/css/new-design/dark-mode.css
+++ b/css/new-design/dark-mode.css
@@ -51,3 +51,9 @@ html.dark-mode .jgljxmt5 {
 html.dark-mode .gitj76qy {
 	max-height: 100vh;
 }
+
+/* Message list: fix for received messages text color in dark mode */
+/* TODO: Remove when fixed by fb */
+.__fb-dark-mode .__fb-light-mode {
+	--primary-text: #e4e6eb;
+}


### PR DESCRIPTION
Messenger website is adding `__fb-light-mode` class to an element in received messages which makes message text dark instead of light in dark mode. This is fixed by setting the `--primary-text` variable to a light color from dark mode in `__fb-light-mode` class only if said class is in a child element of an element containing `__fb-dark-mode` class. This way, the style is applied only in dark mode.

Closes: #1672 