### PR TITLE
Display prompt for Always on Top setting

### DIFF
--- a/source/config.ts
+++ b/source/config.ts
@@ -17,7 +17,8 @@ type StoreType = {
 	menuBarMode: boolean;
 	showDockIcon: boolean;
 	showTrayIcon: boolean;
-	alwaysOnTop?: boolean;
+	alwaysOnTop: boolean;
+	showAlwaysOnTopPrompt: boolean;
 	bounceDockOnMessage: boolean;
 	showUnreadBadge: boolean;
 	showMessageButtons: boolean;
@@ -108,7 +109,12 @@ const schema: Store.Schema<StoreType> = {
 		default: true
 	},
 	alwaysOnTop: {
-		type: 'boolean'
+		type: 'boolean',
+		default: false
+	},
+	showAlwaysOnTopPrompt: {
+		type: 'boolean',
+		default: true
 	},
 	bounceDockOnMessage: {
 		type: 'boolean',

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -334,9 +334,32 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			type: 'checkbox',
 			accelerator: 'CommandOrControl+Shift+T',
 			checked: config.get('alwaysOnTop'),
-			click(menuItem, focusedWindow) {
-				config.set('alwaysOnTop', menuItem.checked);
-				focusedWindow?.setAlwaysOnTop(menuItem.checked);
+			async click(menuItem, focusedWindow, event) {
+				if (!config.get('alwaysOnTop') && config.get('showAlwaysOnTopPrompt') && event.shiftKey) {
+					const result = await dialog.showMessageBox(focusedWindow!, {
+						message: 'Are you sure you want the window to stay on top of other windows?',
+						detail: 'This was triggered by Command/Control+Shift+T.',
+						buttons: [
+							'Display on Top',
+							'Don\'t Display on Top'
+						],
+						defaultId: 0,
+						cancelId: 1,
+						checkboxLabel: 'Don\'t ask me again'
+					});
+
+					config.set('showAlwaysOnTopPrompt', !result.checkboxChecked);
+
+					if (result.response === 0) {
+						config.set('alwaysOnTop', !config.get('alwaysOnTop'));
+						focusedWindow?.setAlwaysOnTop(menuItem.checked);
+					} else if (result.response === 1) {
+						menuItem.checked = false;
+					}
+				} else {
+					config.set('alwaysOnTop', !config.get('alwaysOnTop'));
+					focusedWindow?.setAlwaysOnTop(menuItem.checked);
+				}
 			}
 		},
 		{


### PR DESCRIPTION
Since Ctrl+Shift+T is used for many other things in other programs, it could be helpful to show a prompt when the keyboard shortcut is triggered.

Fixes #1286.

Prompt on Linux:
![image](https://user-images.githubusercontent.com/17033543/129962450-3db020ab-9165-476d-83b8-eb63781d376d.png)
