### PR TITLE
Hide new "Install Messenger App" banner

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -99,7 +99,7 @@ html.private-mode [role='main'] .d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.a8
 }
 
 /* Hide the "Messenger App for Mac/Windows" banner in chat list */
-.os-darwin .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.gl4o1x5y.lt9micmv.qt6c0cv9.jb3vyjys.usczdcwk.iihba337.p8dawk7l,
+.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.gl4o1x5y.lt9micmv.qt6c0cv9.jb3vyjys.usczdcwk.iihba337.p8dawk7l,
 .os-win32 .rq0escxv.l9j0dhe7.du4w35lb.j83agx80.g5gj957u.rj1gh0hx.buofh1pr.hpfvmrgz.i1fnvgqd.bp9cbjyn.owycx6da.btwxx1t3.s9xz0pwp.c4m0enpj.rl78xhln.srn514ro.sn0e7ne5.f6rbj1fe.l3ldwz01 {
 	display: none;
 }


### PR DESCRIPTION
The selector for Mac is now the same one on Windows, so we can remove the `.os-darwin` to make it more generalizable.

I kept the "old" selector, just in case some users still have the older banner type.