### PR TITLE
Fix concatenation of spell check languages

### DIFF
--- a/source/spell-checker.ts
+++ b/source/spell-checker.ts
@@ -84,7 +84,7 @@ function getSpellCheckerLanguages(): MenuItemConstructorOptions[] {
 						config.set('spellCheckerLanguages', languagesChecked);
 					} else {
 						// Add language
-						languagesChecked = [...languagesChecked, ...language];
+						languagesChecked = [...languagesChecked, language];
 						config.set('spellCheckerLanguages', languagesChecked);
 					}
 


### PR DESCRIPTION
While adding a language to the list of available languages for spell check, this was performing a spread operation on the language (introduced in #1723), thereby saving each letter separately. This caused invalid language codes to be saved. Simply removing the spread operator on `language` fixes this.

Fixes #1727.