### PR TITLE
Workaround for notifications

### DIFF
--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -111,6 +111,10 @@ async function discoverIcons(isNewDesign: boolean, element: HTMLElement): Promis
 }
 
 async function getIcon(isNewDesign: boolean, element: HTMLElement, unread: boolean): Promise<string> {
+	if (element === null) {
+		return icon.read;
+	}
+
 	if (!element.getAttribute(icon.read)) {
 		await discoverIcons(isNewDesign, element);
 	}
@@ -152,7 +156,7 @@ async function createConversationNewDesign(element: HTMLElement): Promise<Conver
 	conversation.selected = Boolean(element.querySelector('[role=row] [role=link] > div:only-child'));
 	conversation.unread = Boolean(element.querySelector('[aria-label="Mark as Read"]'));
 
-	const unparsedLabel = element.querySelector<HTMLElement>('.j83agx80.cbu4d94t.ew0dbk1b.irj2b8pg span.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5 > span > span')!;
+	const unparsedLabel = element.querySelector<HTMLElement>('.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7 > span > span')!;
 	conversation.label = await getLabel(unparsedLabel);
 
 	const iconElement = element.querySelector<HTMLElement>('[role=row] [role=link] [role=img] image')!;
@@ -190,14 +194,49 @@ export async function sendConversationList(isNewDesign: boolean): Promise<void> 
 	ipc.callMain('conversations', conversationsToRender);
 }
 
+function countUnread(mutationsList: MutationRecord[]): void {
+	// Look through the mutations for the one with the unread dot
+	const unreadMutations = mutationsList.filter(mutation => mutation.type === 'childList' && mutation.addedNodes.length > 0 && ((mutation.addedNodes[0] as Element).getAttribute('aria-label') === 'Mark as read'));
+
+	for (const mutation of unreadMutations) {
+		let curr = (mutation.addedNodes[0] as Element).parentElement;
+		// Find the parent element with the message preview and sender
+		while (curr?.className !== 'ow4ym5g4 auili1gw rq0escxv j83agx80 buofh1pr g5gj957u i1fnvgqd oygrvhab cxmmr5t8 hcukyx3x kvgmc6g5 tgvbjcpo hpfvmrgz qt6c0cv9 rz4wbd8a a8nywdso jb3vyjys du4w35lb bp9cbjyn btwxx1t3 l9j0dhe7') {
+			curr = curr?.parentElement ?? null;
+		}
+
+		// Get the image data URI from the parent of the author/text
+		const imgUrl = curr.parentElement?.getElementsByTagName('image')[0].getAttribute('data-caprine-icon');
+		// Get the author and text of the new message
+		const titleText = curr.querySelectorAll('.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.jq4qci2q.a3bd9o3v.lrazzd5p.oo9gr5id')[0].textContent;
+		const bodyText = curr.querySelectorAll('.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5')[2].textContent;
+		// Send a notification
+		ipc.callMain('notification', {
+			id: 0,
+			title: titleText,
+			body: bodyText,
+			icon: imgUrl,
+			silent: false
+		});
+	}
+}
+
 window.addEventListener('load', async () => {
 	const sidebar = await elementReady<HTMLElement>('[role=navigation]', {stopOnDomReady: false});
 	const newDesign = await isNewDesign();
 
 	if (sidebar) {
 		const conversationListObserver = new MutationObserver(async () => sendConversationList(newDesign));
+		const conversationCountObserver = new MutationObserver(countUnread);
 
 		conversationListObserver.observe(sidebar, {
+			subtree: true,
+			childList: true,
+			attributes: true,
+			attributeFilter: ['class']
+		});
+
+		conversationCountObserver.observe(sidebar, {
 			subtree: true,
 			childList: true,
 			attributes: true,

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -214,8 +214,24 @@ function countUnread(mutationsList: MutationRecord[]): void {
 		const imgUrl = curr.parentElement?.getElementsByTagName('img')[0].getAttribute('data-caprine-icon');
 		// Get the author and text of the new message
 		// const titleText = curr.querySelectorAll('.d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.jq4qci2q.a3bd9o3v.lrazzd5p.oo9gr5id')[0].textContent;
-		const titleText = curr.querySelectorAll('.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5')[0].textContent;
-		const bodyText = curr.querySelectorAll('.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5')[1].textContent;
+		let titleTextOptions = curr.querySelectorAll('.a8c37x1j.d2edcug0.ni8dbmo4.ltmttdrg.g0qnabr5');
+		if (titleTextOptions.length === 0) {
+			titleTextOptions = curr.querySelectorAll('.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5');
+		}
+
+		const titleText = titleTextOptions[0].textContent;
+		let bodyTextOptions = curr.querySelectorAll('.a8c37x1j.ni8dbmo4.stjgntxs.l9j0dhe7.ltmttdrg.g0qnabr5');
+		if (bodyTextOptions.length === 0) {
+			bodyTextOptions = curr.querySelectorAll('.a8c37x1j.d2edcug0.ni8dbmo4.ltmttdrg.g0qnabr5');
+		}
+
+		let loc = 0;
+		if (bodyTextOptions.length >= 2) {
+			loc = 1;
+		}
+
+		const bodyText = bodyTextOptions[loc].textContent;
+
 		// Send a notification
 		ipc.callMain('notification', {
 			id: 0,


### PR DESCRIPTION
Notifications have not been working since the redesign (Workaround for #1562). This PR aims to work around this missing functionality.

The message sidebar changes to show the unread dot when a new message is received. A mutation event listener has been added to watch for this new blue dot. When the dot appears, we can obtain the message content, message author, and profile picture of the chat and send a notification using existing notification functions.

The downside with this workaround is that there is no notification when multiple new messages are received in the same chat (when the blue dot already exists and a new message is received). However, I believe just having some notification is far better than the current status of not having any notification.

There were also a couple of errors in obtaining the conversation list for other functions in `index.ts`. I have thus updated the class list and modified the functions to reduce the likelihood of errors.

Example notification on KDE Plasma:
![image](https://user-images.githubusercontent.com/16456478/144301566-16e1cde2-dc66-4143-a411-02d92f9c7afb.png)
