### PR TITLE
Fix dark mode

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -382,6 +382,14 @@ function setThemeElement(element: HTMLElement): void {
 	element.classList.toggle('light-mode', !useDarkColors);
 	element.classList.toggle('__fb-dark-mode', useDarkColors);
 	element.classList.toggle('__fb-light-mode', !useDarkColors);
+
+	// TODO: Workaround for Facebooks buggy frontend
+	// The ui sometimes hardcodes ligth mode classes in the ui. This removes them so the class
+	// in the root element would be used.
+	const className = useDarkColors ? '__fb-light-mode' : '__fb-dark-mode';
+	for (const element of document.querySelectorAll(`.${className}`)) {
+		element.classList.remove(className);
+	}
 }
 
 async function observeTheme(): Promise<void> {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -382,7 +382,10 @@ function setThemeElement(element: HTMLElement): void {
 	element.classList.toggle('light-mode', !useDarkColors);
 	element.classList.toggle('__fb-dark-mode', useDarkColors);
 	element.classList.toggle('__fb-light-mode', !useDarkColors);
+	removeThemeClasses(useDarkColors);
+}
 
+function removeThemeClasses(useDarkColors: boolean): void {
 	// TODO: Workaround for Facebooks buggy frontend
 	// The ui sometimes hardcodes ligth mode classes in the ui. This removes them so the class
 	// in the root element would be used.
@@ -799,6 +802,19 @@ async function observeAutoscroll(): Promise<void> {
 	conversationObserver.observe(mainElement, {childList: true});
 }
 
+async function observeThemeBugs(): Promise<void> {
+	const rootObserver = new MutationObserver((record: MutationRecord[]) => {
+		const newNodes: MutationRecord[] = record
+			.filter(record => record.addedNodes.length > 0 || record.removedNodes.length > 0);
+
+		if (newNodes) {
+			removeThemeClasses(Boolean(api.nativeTheme.shouldUseDarkColors));
+		}
+	});
+
+	rootObserver.observe(document.documentElement, {childList: true, subtree: true});
+}
+
 // Listen for emoji element dom insertion
 document.addEventListener('animationstart', insertionListener, false);
 
@@ -844,6 +860,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 	// Hook auto-scroll observer
 	observeAutoscroll();
+
+	// Hook broken dark mode observer
+	observeThemeBugs();
 });
 
 // Handle title bar double-click.


### PR DESCRIPTION
This is a workaround for the issue with dark mode being broken by use of light mode classes in some elements in ui. This is creating a major problem since received messages are unreadable.

It's not an ideal solution since it uses mutation observer on root element so any suggestions are welcome.

Closes: #1737
Closes: #1738 
Closes: #1740