### PR TITLE
Bump electron-builder version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"@types/lodash": "^4.14.165",
 				"del-cli": "^3.0.1",
 				"electron": "^10.1.5",
-				"electron-builder": "^22.9.1",
+				"electron-builder": "^22.14.5",
 				"husky": "^4.3.0",
 				"np": "^7.0.0",
 				"stylelint": "^13.8.0",
@@ -1700,9 +1700,9 @@
 			"dev": true
 		},
 		"node_modules/app-builder-lib": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.13.1.tgz",
-			"integrity": "sha512-TsUe7gCdH1cnSknUcqwVRAAxsFxsxcU/BJvnKR8ASzjaZtePW7MU+AEaDVDUURycgYxQ9XeymGjmuQGS32jcbw==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.5.tgz",
+			"integrity": "sha512-k3VwKP4kpsnUaXoUkm1s4zaSHPHIMFnN4kPMU9yXaKmE1LfHHqBaEah5bXeTAX5V/BC41wFdg8CF5vOjvgy8Rg==",
 			"dev": true,
 			"dependencies": {
 				"@develar/schema-utils": "~2.6.5",
@@ -1711,13 +1711,14 @@
 				"7zip-bin": "~5.1.1",
 				"async-exit-hook": "^2.0.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"chromium-pickle-js": "^0.2.0",
 				"debug": "^4.3.2",
 				"ejs": "^3.1.6",
 				"electron-osx-sign": "^0.5.0",
-				"electron-publish": "22.13.1",
+				"electron-publish": "22.14.5",
+				"form-data": "^4.0.0",
 				"fs-extra": "^10.0.0",
 				"hosted-git-info": "^4.0.2",
 				"is-ci": "^3.0.0",
@@ -1956,6 +1957,12 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"node_modules/at-least-node": {
 			"version": "1.0.0",
@@ -2314,9 +2321,9 @@
 			"dev": true
 		},
 		"node_modules/builder-util": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.13.1.tgz",
-			"integrity": "sha512-gMdoW9aQbWYxuQ4k4jT4An1BTo/hWzvsdv3pwNz18iNYnqn9j+xMllQOg9CHgfQYKSUd8VuMsZnbCvLO4NltYw==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.5.tgz",
+			"integrity": "sha512-zqIHDFJwmA7jV7SC9aI+33MWwT2mWoijH+Ol9IntNAwuuRXoS+7XeJwnhLBXOhcDBzXT4kDzHnRk4JKeaygEYA==",
 			"dev": true,
 			"dependencies": {
 				"@types/debug": "^4.1.6",
@@ -2324,7 +2331,7 @@
 				"7zip-bin": "~5.1.1",
 				"app-builder-bin": "3.7.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util-runtime": "8.8.1",
+				"builder-util-runtime": "8.9.1",
 				"chalk": "^4.1.1",
 				"cross-spawn": "^7.0.3",
 				"debug": "^4.3.2",
@@ -2337,9 +2344,9 @@
 			}
 		},
 		"node_modules/builder-util-runtime": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz",
-			"integrity": "sha512-xHxAzdsJmMV8m/N+INzYUKfyJASeKyKHnA1uGkY8Y8JKLI/c4BG+If+L0If2YETv96CiRASkvd02tIt2pvrchQ==",
+			"version": "8.9.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
+			"integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.2",
@@ -2759,17 +2766,39 @@
 			}
 		},
 		"node_modules/cli-truncate": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-			"dev": true,
-			"optional": true,
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
 			"dependencies": {
-				"slice-ansi": "^1.0.0",
-				"string-width": "^2.0.0"
+				"slice-ansi": "^3.0.0",
+				"string-width": "^4.2.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/cli-width": {
@@ -2897,6 +2926,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/commander": {
@@ -3319,6 +3360,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/detect-node": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -3366,14 +3416,14 @@
 			}
 		},
 		"node_modules/dmg-builder": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.13.1.tgz",
-			"integrity": "sha512-qgfLN2fo4q2wIWNvbcKlZ71DLRDLvWIElOB7oxlSxUrMi6xhI+9v1Mh7E0FJ+r5UXhQzaQXaGuyMsQRbGgrSwg==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.5.tgz",
+			"integrity": "sha512-1GvFGQE332bvPamcMwZDqWqfWfJTyyDLOsHMcGi0zs+Jh7JOn6/zuBkHJIWHdsj2QJbhzLVyd2/ZqttOKv7I8w==",
 			"dev": true,
 			"dependencies": {
-				"app-builder-lib": "22.13.1",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"app-builder-lib": "22.14.5",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"fs-extra": "^10.0.0",
 				"iconv-lite": "^0.6.2",
 				"js-yaml": "^4.1.0"
@@ -3418,9 +3468,9 @@
 			}
 		},
 		"node_modules/dmg-license": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.9.tgz",
-			"integrity": "sha512-Rq6qMDaDou2+aPN2SYy0x7LDznoJ/XaG6oDcH5wXUp+WRWQMUYE6eM+F+nex+/LSXOp1uw4HLFoed0YbfU8R/Q==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.10.tgz",
+			"integrity": "sha512-SVeeyiOeinV5JCPHXMdKOgK1YVbak/4+8WL2rBnfqRYpA5FaeFaQnQWb25x628am1w70CbipGDv9S51biph63A==",
 			"dev": true,
 			"optional": true,
 			"os": [
@@ -3430,10 +3480,9 @@
 				"@types/plist": "^3.0.1",
 				"@types/verror": "^1.10.3",
 				"ajv": "^6.10.0",
-				"cli-truncate": "^1.1.0",
 				"crc": "^3.8.0",
-				"iconv-corefoundation": "^1.1.6",
-				"plist": "^3.0.1",
+				"iconv-corefoundation": "^1.1.7",
+				"plist": "^3.0.4",
 				"smart-buffer": "^4.0.2",
 				"verror": "^1.10.0"
 			},
@@ -3610,17 +3659,17 @@
 			}
 		},
 		"node_modules/electron-builder": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.13.1.tgz",
-			"integrity": "sha512-ajlI40L60qKBBxvpf770kcjxHAccMpEWpwsHAppytl3WmWgJfMut4Wz9VUFqyNtX/9a624QTatk6TqoxqewRug==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.5.tgz",
+			"integrity": "sha512-N73hSbXFz6Mz5Z6h6C5ly6CB+dUN6k1LuCDJjI8VF47bMXv/QE0HE+Kkb0GPKqTqM7Hsk/yIYX+kHCfSkR5FGg==",
 			"dev": true,
 			"dependencies": {
 				"@types/yargs": "^17.0.1",
-				"app-builder-lib": "22.13.1",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"app-builder-lib": "22.14.5",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"chalk": "^4.1.1",
-				"dmg-builder": "22.13.1",
+				"dmg-builder": "22.14.5",
 				"fs-extra": "^10.0.0",
 				"is-ci": "^3.0.0",
 				"lazy-val": "^1.0.5",
@@ -3682,55 +3731,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/electron-context-menu/node_modules/cli-truncate": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-			"dependencies": {
-				"slice-ansi": "^3.0.0",
-				"string-width": "^4.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/electron-context-menu/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/electron-context-menu/node_modules/slice-ansi": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-			"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"astral-regex": "^2.0.0",
-				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/electron-context-menu/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/electron-debug": {
@@ -3828,14 +3828,14 @@
 			"dev": true
 		},
 		"node_modules/electron-publish": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.13.1.tgz",
-			"integrity": "sha512-5nCXhnsqrRxP5NsZxUKjiMkcFmQglXp7i/YY4rp3h1s1psg3utOIkM29Z93YTSXicZJU1J+8811eo5HX1vpoKg==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.5.tgz",
+			"integrity": "sha512-h+NANRdaA0PqGF15GKvorseWPzh1PXa/zx4I37//PIokW8eKIov8ky23foUSb55ZFWUHGpxQJux7y2NCfBtQeg==",
 			"dev": true,
 			"dependencies": {
 				"@types/fs-extra": "^9.0.11",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"chalk": "^4.1.1",
 				"fs-extra": "^10.0.0",
 				"lazy-val": "^1.0.5",
@@ -5468,9 +5468,9 @@
 			"dev": true
 		},
 		"node_modules/extsprintf": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
-			"integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+			"integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
 			"dev": true,
 			"engines": [
 				"node >=0.6.0"
@@ -5758,6 +5758,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/fragment-cache": {
@@ -6440,16 +6454,16 @@
 			}
 		},
 		"node_modules/iconv-corefoundation": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.6.tgz",
-			"integrity": "sha512-1NBe55C75bKGZaY9UHxvXG3G0gEp0ziht7quhuFrW3SPgZDw9HI6qvYXRSV5M/Eupyu8ljuJ6Cba+ec15PZ4Xw==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+			"integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
 			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
 			],
 			"dependencies": {
-				"cli-truncate": "^1.1.0",
+				"cli-truncate": "^2.1.0",
 				"node-addon-api": "^1.6.3"
 			},
 			"engines": {
@@ -7097,9 +7111,9 @@
 			}
 		},
 		"node_modules/is-ci/node_modules/ci-info": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-			"integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
 			"dev": true
 		},
 		"node_modules/is-core-module": {
@@ -8790,9 +8804,9 @@
 			}
 		},
 		"node_modules/mime": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-			"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
 			"dev": true,
 			"bin": {
 				"mime": "cli.js"
@@ -8814,7 +8828,6 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
 			"integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.50.0"
 			},
@@ -11469,16 +11482,24 @@
 			}
 		},
 		"node_modules/slice-ansi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+			"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
 			"dependencies": {
-				"is-fullwidth-code-point": "^2.0.0"
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/smart-buffer": {
@@ -13246,18 +13267,18 @@
 			}
 		},
 		"node_modules/verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+			"integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
 			"dev": true,
-			"engines": [
-				"node >=0.6.0"
-			],
 			"optional": true,
 			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=0.6.0"
 			}
 		},
 		"node_modules/verror/node_modules/core-util-is": {
@@ -15471,9 +15492,9 @@
 			"dev": true
 		},
 		"app-builder-lib": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.13.1.tgz",
-			"integrity": "sha512-TsUe7gCdH1cnSknUcqwVRAAxsFxsxcU/BJvnKR8ASzjaZtePW7MU+AEaDVDUURycgYxQ9XeymGjmuQGS32jcbw==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.14.5.tgz",
+			"integrity": "sha512-k3VwKP4kpsnUaXoUkm1s4zaSHPHIMFnN4kPMU9yXaKmE1LfHHqBaEah5bXeTAX5V/BC41wFdg8CF5vOjvgy8Rg==",
 			"dev": true,
 			"requires": {
 				"@develar/schema-utils": "~2.6.5",
@@ -15482,13 +15503,14 @@
 				"7zip-bin": "~5.1.1",
 				"async-exit-hook": "^2.0.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"chromium-pickle-js": "^0.2.0",
 				"debug": "^4.3.2",
 				"ejs": "^3.1.6",
 				"electron-osx-sign": "^0.5.0",
-				"electron-publish": "22.13.1",
+				"electron-publish": "22.14.5",
+				"form-data": "^4.0.0",
 				"fs-extra": "^10.0.0",
 				"hosted-git-info": "^4.0.2",
 				"is-ci": "^3.0.0",
@@ -15658,6 +15680,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
 			"integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
 		"at-least-node": {
@@ -15914,9 +15942,9 @@
 			"dev": true
 		},
 		"builder-util": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.13.1.tgz",
-			"integrity": "sha512-gMdoW9aQbWYxuQ4k4jT4An1BTo/hWzvsdv3pwNz18iNYnqn9j+xMllQOg9CHgfQYKSUd8VuMsZnbCvLO4NltYw==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.14.5.tgz",
+			"integrity": "sha512-zqIHDFJwmA7jV7SC9aI+33MWwT2mWoijH+Ol9IntNAwuuRXoS+7XeJwnhLBXOhcDBzXT4kDzHnRk4JKeaygEYA==",
 			"dev": true,
 			"requires": {
 				"@types/debug": "^4.1.6",
@@ -15924,7 +15952,7 @@
 				"7zip-bin": "~5.1.1",
 				"app-builder-bin": "3.7.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util-runtime": "8.8.1",
+				"builder-util-runtime": "8.9.1",
 				"chalk": "^4.1.1",
 				"cross-spawn": "^7.0.3",
 				"debug": "^4.3.2",
@@ -15966,9 +15994,9 @@
 			}
 		},
 		"builder-util-runtime": {
-			"version": "8.8.1",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz",
-			"integrity": "sha512-xHxAzdsJmMV8m/N+INzYUKfyJASeKyKHnA1uGkY8Y8JKLI/c4BG+If+L0If2YETv96CiRASkvd02tIt2pvrchQ==",
+			"version": "8.9.1",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.1.tgz",
+			"integrity": "sha512-c8a8J3wK6BIVLW7ls+7TRK9igspTbzWmUqxFbgK0m40Ggm6efUbxtWVCGIjc+dtchyr5qAMAUL6iEGRdS/6vwg==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.3.2",
@@ -16268,14 +16296,29 @@
 			}
 		},
 		"cli-truncate": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-			"dev": true,
-			"optional": true,
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
 			"requires": {
-				"slice-ansi": "^1.0.0",
-				"string-width": "^2.0.0"
+				"slice-ansi": "^3.0.0",
+				"string-width": "^4.2.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				}
 			}
 		},
 		"cli-width": {
@@ -16376,6 +16419,15 @@
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
 			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
 			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
 		},
 		"commander": {
 			"version": "5.1.0",
@@ -16697,6 +16749,12 @@
 				"meow": "^6.1.1"
 			}
 		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
 		"detect-node": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -16737,14 +16795,14 @@
 			}
 		},
 		"dmg-builder": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.13.1.tgz",
-			"integrity": "sha512-qgfLN2fo4q2wIWNvbcKlZ71DLRDLvWIElOB7oxlSxUrMi6xhI+9v1Mh7E0FJ+r5UXhQzaQXaGuyMsQRbGgrSwg==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.5.tgz",
+			"integrity": "sha512-1GvFGQE332bvPamcMwZDqWqfWfJTyyDLOsHMcGi0zs+Jh7JOn6/zuBkHJIWHdsj2QJbhzLVyd2/ZqttOKv7I8w==",
 			"dev": true,
 			"requires": {
-				"app-builder-lib": "22.13.1",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"app-builder-lib": "22.14.5",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"dmg-license": "^1.0.9",
 				"fs-extra": "^10.0.0",
 				"iconv-lite": "^0.6.2",
@@ -16781,19 +16839,18 @@
 			}
 		},
 		"dmg-license": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.9.tgz",
-			"integrity": "sha512-Rq6qMDaDou2+aPN2SYy0x7LDznoJ/XaG6oDcH5wXUp+WRWQMUYE6eM+F+nex+/LSXOp1uw4HLFoed0YbfU8R/Q==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.10.tgz",
+			"integrity": "sha512-SVeeyiOeinV5JCPHXMdKOgK1YVbak/4+8WL2rBnfqRYpA5FaeFaQnQWb25x628am1w70CbipGDv9S51biph63A==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"@types/plist": "^3.0.1",
 				"@types/verror": "^1.10.3",
 				"ajv": "^6.10.0",
-				"cli-truncate": "^1.1.0",
 				"crc": "^3.8.0",
-				"iconv-corefoundation": "^1.1.6",
-				"plist": "^3.0.1",
+				"iconv-corefoundation": "^1.1.7",
+				"plist": "^3.0.4",
 				"smart-buffer": "^4.0.2",
 				"verror": "^1.10.0"
 			}
@@ -16926,17 +16983,17 @@
 			}
 		},
 		"electron-builder": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.13.1.tgz",
-			"integrity": "sha512-ajlI40L60qKBBxvpf770kcjxHAccMpEWpwsHAppytl3WmWgJfMut4Wz9VUFqyNtX/9a624QTatk6TqoxqewRug==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.14.5.tgz",
+			"integrity": "sha512-N73hSbXFz6Mz5Z6h6C5ly6CB+dUN6k1LuCDJjI8VF47bMXv/QE0HE+Kkb0GPKqTqM7Hsk/yIYX+kHCfSkR5FGg==",
 			"dev": true,
 			"requires": {
 				"@types/yargs": "^17.0.1",
-				"app-builder-lib": "22.13.1",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"app-builder-lib": "22.14.5",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"chalk": "^4.1.1",
-				"dmg-builder": "22.13.1",
+				"dmg-builder": "22.14.5",
 				"fs-extra": "^10.0.0",
 				"is-ci": "^3.0.0",
 				"lazy-val": "^1.0.5",
@@ -16982,42 +17039,6 @@
 				"cli-truncate": "^2.1.0",
 				"electron-dl": "^3.1.0",
 				"electron-is-dev": "^1.2.0"
-			},
-			"dependencies": {
-				"cli-truncate": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-					"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-					"requires": {
-						"slice-ansi": "^3.0.0",
-						"string-width": "^4.2.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
-				"slice-ansi": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-					"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"astral-regex": "^2.0.0",
-						"is-fullwidth-code-point": "^3.0.0"
-					}
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				}
 			}
 		},
 		"electron-debug": {
@@ -17101,14 +17122,14 @@
 			}
 		},
 		"electron-publish": {
-			"version": "22.13.1",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.13.1.tgz",
-			"integrity": "sha512-5nCXhnsqrRxP5NsZxUKjiMkcFmQglXp7i/YY4rp3h1s1psg3utOIkM29Z93YTSXicZJU1J+8811eo5HX1vpoKg==",
+			"version": "22.14.5",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.14.5.tgz",
+			"integrity": "sha512-h+NANRdaA0PqGF15GKvorseWPzh1PXa/zx4I37//PIokW8eKIov8ky23foUSb55ZFWUHGpxQJux7y2NCfBtQeg==",
 			"dev": true,
 			"requires": {
 				"@types/fs-extra": "^9.0.11",
-				"builder-util": "22.13.1",
-				"builder-util-runtime": "8.8.1",
+				"builder-util": "22.14.5",
+				"builder-util-runtime": "8.9.1",
 				"chalk": "^4.1.1",
 				"fs-extra": "^10.0.0",
 				"lazy-val": "^1.0.5",
@@ -18358,9 +18379,9 @@
 			}
 		},
 		"extsprintf": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
-			"integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+			"integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
 			"dev": true,
 			"optional": true
 		},
@@ -18587,6 +18608,17 @@
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
+		},
+		"form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -19099,13 +19131,13 @@
 			}
 		},
 		"iconv-corefoundation": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.6.tgz",
-			"integrity": "sha512-1NBe55C75bKGZaY9UHxvXG3G0gEp0ziht7quhuFrW3SPgZDw9HI6qvYXRSV5M/Eupyu8ljuJ6Cba+ec15PZ4Xw==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+			"integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"cli-truncate": "^1.1.0",
+				"cli-truncate": "^2.1.0",
 				"node-addon-api": "^1.6.3"
 			}
 		},
@@ -19576,9 +19608,9 @@
 			},
 			"dependencies": {
 				"ci-info": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-					"integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+					"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
 					"dev": true
 				}
 			}
@@ -20839,9 +20871,9 @@
 			}
 		},
 		"mime": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-			"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -20854,7 +20886,6 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
 			"integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"mime-db": "1.50.0"
 			}
@@ -22817,13 +22848,20 @@
 			"dev": true
 		},
 		"slice-ansi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+			"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0"
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+				}
 			}
 		},
 		"smart-buffer": {
@@ -24210,9 +24248,9 @@
 			}
 		},
 		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+			"integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
 			"dev": true,
 			"optional": true,
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@types/lodash": "^4.14.165",
 		"del-cli": "^3.0.1",
 		"electron": "^10.1.5",
-		"electron-builder": "^22.9.1",
+		"electron-builder": "^22.14.5",
 		"husky": "^4.3.0",
 		"np": "^7.0.0",
 		"stylelint": "^13.8.0",


### PR DESCRIPTION
In electron-builder there is an [issue with publishing snap packages](https://github.com/electron-userland/electron-builder/issues/6327) on version that is currently used in CI (22.13.1). This is fixed in eb 22.14.5. Only bumping the version fixes this issue. Since snap packages have not been published for past few version, this didn't affect Caprine.