### PR TITLE
Use 'emoji' font alias on Linux for system emoji

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -539,7 +539,7 @@ ipc.answerMain('render-overlay-icon', (messageCount: number): {data: string; tex
 ipc.answerMain('render-native-emoji', (emoji: string): string => {
 	const canvas = document.createElement('canvas');
 	const context = canvas.getContext('2d')!;
-	const systemFont = is.linux ? 'emoji' : 'system-ui';
+	const systemFont = is.linux ? 'emoji, system-ui' : 'system-ui';
 	canvas.width = 256;
 	canvas.height = 256;
 	context.textAlign = 'center';

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -539,16 +539,17 @@ ipc.answerMain('render-overlay-icon', (messageCount: number): {data: string; tex
 ipc.answerMain('render-native-emoji', (emoji: string): string => {
 	const canvas = document.createElement('canvas');
 	const context = canvas.getContext('2d')!;
+	const systemFont = is.linux ? 'emoji' : 'system-ui';
 	canvas.width = 256;
 	canvas.height = 256;
 	context.textAlign = 'center';
 	context.textBaseline = 'middle';
 	if (is.macos) {
-		context.font = '256px system-ui';
+		context.font = `256px ${systemFont}`;
 		context.fillText(emoji, 128, 154);
 	} else {
 		context.textBaseline = 'bottom';
-		context.font = '225px system-ui';
+		context.font = `225px ${systemFont}`;
 		context.fillText(emoji, 128, 256);
 	}
 


### PR DESCRIPTION
On Linux with fontconfig, the system font for emoji is the "emoji" font rather than "system-ui" [1-2]. When using the system-ui font on standard configurations, it falls back to using "sans-serif" before the emoji font, in my case Arimo before Noto Color Emoji:

```bash
$ fc-match system-ui
Arimo-Regular.ttf: "Arimo" "Regular"
```

This presents a problem for emoji characters which are included as monochrome unicode glyphs in the sans-serif font (such as the smiley face ☺), since these are rendered with the monochrome characters from sans-serif rather than the emoji font. This patch makes use of the emoji alias shipped by default in fontconfig on Linux systems to preferentially use the system emoji font.

[1] https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/conf.d/45-generic.conf
[2] https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/conf.d/60-generic.conf