### PR TITLE
Fix css selectors to hide search in compact mode

### DIFF
--- a/css/new-design/browser.css
+++ b/css/new-design/browser.css
@@ -119,10 +119,10 @@ html.private-mode [role='main'] .d2edcug0.hpfvmrgz.qv66sw1b.c1et5uql.b0tq1wua.a8
 }
 
 @media (max-width: 900px) {
-	.os-darwin .rq0escxv.l9j0dhe7.du4w35lb.n851cfcs.aahdfvyu {
+	.os-darwin .rq0escxv.l9j0dhe7.du4w35lb.jbae33se.hv4rvrfc.dati1w0a.pybr56ya {
 		display: none !important;
 	}
-	.os-darwin .hybvsw6c.cjfnh4rs.j83agx80.cbu4d94t.dp1hu0rb.l9j0dhe7.kr520xx4.iyyx5f41.jyyn76af.ow71b3p4.pnfry9he.so2p5rfc.owhy4gn4.wrtwqps9 {
+	.os-darwin .rpm2j7zs.k7i0oixp.gvuykj2m.j83agx80.cbu4d94t.ni8dbmo4.du4w35lb.q5bimw55.ofs802cu.pohlnb88.dkue75c7.mb9wzai9.d8ncny3e.buofh1pr.g5gj957u.tgvbjcpo.l56l04vs.r57mb794.kh7kg01d.eg9m0zos.c3g1iek1.l9j0dhe7.k4xni2cv {
 		padding-top: 36px !important;
 	}
 }


### PR DESCRIPTION
This should fix the problem with search bar showing in compact mode (at least until the class list changes again).

Fixes #1780 