### PR TITLE
Fix dark button for New Room

### DIFF
--- a/css/new-design/dark-mode.css
+++ b/css/new-design/dark-mode.css
@@ -5,8 +5,8 @@
 	color: var(--primary-text);
 }
 
-/* Preferences: Icon color */
-[role='dialog'] .a8c37x1j.ms05siws.hwsy1cff.b7h9ocf4 {
+/* Preferences and New Room: Icon color */
+[role='button'] .a8c37x1j.ms05siws.l3qrxjdp.b7h9ocf4 {
 	fill: currentColor;
 	color: var(--primary-text);
 }


### PR DESCRIPTION
Also affects Preferences (but doesn't actually need the custom CSS any more). The "new message" button, however, is `[role='link']`.