### PR TITLE
Fix workaround for notifications

### DIFF
--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -143,7 +143,13 @@ async function getLabel(element: HTMLElement): Promise<string> {
 		return '';
 	}
 
-	const emojis: HTMLElement[] = [...element.children] as HTMLElement[];
+	const emojis: HTMLElement[] = [];
+	if (element !== null) {
+		for (const element_curr of element.children) {
+			emojis.push(element_curr as HTMLElement);
+		}
+	}
+
 	for (const emoji of emojis) {
 		emoji.outerHTML = emoji.querySelector('img')?.getAttribute('alt') ?? '';
 	}


### PR DESCRIPTION
A fix for system notifications post-redesign (#1562) was merged (#1739).

A change in Messenger has caused a null element causing the notification workaround to no longer function.

This will now verify that the element is not null before attempting to use its properties, no longer resulting in an exception and allowing the notification functionality to function as intended again.