### PR TITLE
Select log out as last menu item

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -66,7 +66,12 @@ async function selectMenuItem(isNewDesign: boolean, itemNumber: number): Promise
 			`${conversationMenuSelectorNewDesign} [role=menuitem]`
 		);
 
-		selector = itemNumber <= items.length ? items[itemNumber - 1] : null;
+		// Negative items will select from the end
+		if (itemNumber < 0) {
+			selector = -itemNumber <= items.length ? items[items.length + itemNumber] : null;
+		} else {
+			selector = itemNumber <= items.length ? items[itemNumber - 1] : null;
+		}
 	} else {
 		selector = document.querySelector<HTMLElement>(
 			`${conversationMenuSelector} > li:nth-child(${itemNumber}) a`
@@ -128,7 +133,7 @@ ipc.answerMain('log-out', async () => {
 		const newDesign = await isNewDesign();
 		await withSettingsMenu(newDesign, () => {
 			if (newDesign) {
-				selectMenuItem(newDesign, 11);
+				selectMenuItem(newDesign, -1);
 			} else {
 				const nodes = document.querySelectorAll<HTMLElement>(
 					'._54nq._2i-c._558b._2n_z li:last-child a'


### PR DESCRIPTION
Added functionality to select negatively indexed menu items, since "Log out" is always last in the menu item list.

[Selecting item 11 broke when another "New! Messenger for Windows" item was added to the list. I think that "Log out" will stay as the last item, so this should be more future-proof, but we'll see what the Messenger backend devs do.]