### PR TITLE
Fix release publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,8 +119,7 @@
 		"linux": {
 			"target": [
 				"AppImage",
-				"deb",
-				"snap"
+				"deb"
 			],
 			"icon": "build/icons/",
 			"synopsis": "Elegant Facebook Messenger desktop app",


### PR DESCRIPTION
Release publishing was broken since snap target was not removed from electron-builder config. This should stop the building of snap and thus fix the publishing.

Closes: #1848 