### PR TITLE
Revert "Add rpm to Linux targets"

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
 		"linux": {
 			"target": [
 				"AppImage",
-				"deb"
+				"deb",
+				"rpm"
 			],
 			"icon": "build/icons/",
 			"synopsis": "Elegant Facebook Messenger desktop app",

--- a/package.json
+++ b/package.json
@@ -122,8 +122,7 @@
 		"linux": {
 			"target": [
 				"AppImage",
-				"deb",
-				"rpm"
+				"deb"
 			],
 			"icon": "build/icons/",
 			"synopsis": "Elegant Facebook Messenger desktop app",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"main": "dist-js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=16"
 	},
 	"scripts": {
 		"postinstall": "patch-package && electron-builder install-app-deps",

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -6,6 +6,7 @@ import {
 	Response,
 	Menu
 } from 'electron';
+import {is} from 'electron-util';
 import {memoize} from 'lodash';
 import config from './config';
 import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
@@ -340,10 +341,12 @@ export async function generateSubmenu(
 ): Promise<MenuItemConstructorOptions[]> {
 	const emojiMenuOption = async (
 		label: string,
-		style: EmojiStyle
+		style: EmojiStyle,
+		visibility: boolean
 	): Promise<MenuItemConstructorOptions> => ({
 		label,
 		type: 'checkbox',
+		visible: visibility,
 		icon: await getEmojiIcon(style),
 		checked: config.get('emojiStyle') === style,
 		async click() {
@@ -359,10 +362,10 @@ export async function generateSubmenu(
 	});
 
 	return Promise.all([
-		emojiMenuOption('System', EmojiStyle.Native),
+		emojiMenuOption('System', EmojiStyle.Native, true),
 		{type: 'separator'} as const,
-		emojiMenuOption('Facebook 3.0', EmojiStyle.Facebook30),
-		emojiMenuOption('Messenger 1.0', EmojiStyle.Messenger10),
-		emojiMenuOption('Facebook 2.2', EmojiStyle.Facebook22)
+		emojiMenuOption('Facebook 3.0', EmojiStyle.Facebook30, true),
+		emojiMenuOption('Messenger 1.0', EmojiStyle.Messenger10, !is.linux || is.development),
+		emojiMenuOption('Facebook 2.2', EmojiStyle.Facebook22, true)
 	]);
 }

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -239,7 +239,10 @@ Press Command/Ctrl+R in Caprine to see your changes.
 
 	const preferencesSubmenu: MenuItemConstructorOptions[] = [
 		{
+			/* TODO: Fix privacy features */
+			/* If you want to help, see #1688 */
 			label: 'Privacy',
+			visible: is.development,
 			submenu: privacySubmenu
 		},
 		{
@@ -266,17 +269,21 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			/* TODO: Fix notifications */
 			label: 'Show Message Preview in Notifications',
 			type: 'checkbox',
+			visible: is.development,
 			checked: config.get('notificationMessagePreview'),
 			click(menuItem) {
 				config.set('notificationMessagePreview', menuItem.checked);
 			}
 		},
 		{
+			/* TODO: Fix notifications */
 			label: 'Mute Notifications',
 			id: 'mute-notifications',
 			type: 'checkbox',
+			visible: is.development,
 			checked: config.get('notificationsMuted'),
 			click() {
 				sendAction('toggle-mute-notifications', {isNewDesign});
@@ -291,8 +298,10 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			/* TODO: Fix notification badge */
 			label: 'Show Unread Badge',
 			type: 'checkbox',
+			visible: is.development,
 			checked: config.get('showUnreadBadge'),
 			click() {
 				config.set('showUnreadBadge', !config.get('showUnreadBadge'));
@@ -363,6 +372,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			/* TODO: Add support for Linux */
 			label: 'Launch at Login',
 			visible: !is.linux,
 			type: 'checkbox',
@@ -402,9 +412,10 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			}
 		},
 		{
+			/* TODO: Fix notifications */
 			label: 'Flash Window on Message',
 			type: 'checkbox',
-			visible: !is.macos,
+			visible: is.development,
 			checked: config.get('flashWindowOnMessage'),
 			click(menuItem) {
 				config.set('flashWindowOnMessage', menuItem.checked);
@@ -567,55 +578,63 @@ Press Command/Ctrl+R in Caprine to see your changes.
 
 	const conversationSubmenu: MenuItemConstructorOptions[] = [
 		{
+			/* TODO: Fix conversation controls */
 			label: 'Mute Conversation',
+			visible: is.development,
 			accelerator: 'CommandOrControl+Shift+M',
 			click() {
 				sendAction<INewDesign>('mute-conversation', {isNewDesign});
 			}
 		},
 		{
+			/* TODO: Fix conversation controls */
 			label: 'Hide Conversation',
+			visible: is.development,
 			accelerator: 'CommandOrControl+Shift+H',
 			click() {
 				sendAction<INewDesign>('hide-conversation', {isNewDesign});
 			}
 		},
 		{
+			/* TODO: Fix conversation controls */
 			label: 'Delete Conversation',
+			visible: is.development,
 			accelerator: 'CommandOrControl+Shift+D',
 			click() {
 				sendAction<INewDesign>('delete-conversation', {isNewDesign});
 			}
 		},
 		{
-			type: 'separator'
-		},
-		{
+			/* TODO: Fix conversation controls */
 			label: 'Select Next Conversation',
+			visible: is.development,
 			accelerator: 'Control+Tab',
 			click() {
 				sendAction('next-conversation');
 			}
 		},
 		{
+			/* TODO: Fix conversation controls */
 			label: 'Select Previous Conversation',
+			visible: is.development,
 			accelerator: 'Control+Shift+Tab',
 			click() {
 				sendAction('previous-conversation');
 			}
 		},
 		{
-			type: 'separator'
-		},
-		{
+			/* TODO: Fix conversation controls */
 			label: 'Find Conversation',
+			visible: is.development,
 			accelerator: 'CommandOrControl+K',
 			click() {
 				sendAction('find');
 			}
 		},
 		{
+			/* TODO: Fix conversation controls */
 			label: 'Search in Conversation',
+			visible: is.development,
 			accelerator: 'CommandOrControl+F',
 			click() {
 				sendAction('search', isNewDesign);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
 		"outDir": "dist-js",
-		"target": "es2018",
+		"target": "ES2022",
 		"module": "commonjs",
 		"esModuleInterop": true,
 		"lib": [


### PR DESCRIPTION
This reverts commit 53241a24fa910ea935635f03ab793c043f877d12.

Rpm packages are already maintained in a third party [copr](https://copr.fedorainfracloud.org/coprs/dusansimic/caprine/) repository.