### PR TITLE
Restore snap publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           node-version: 14
       - uses: c-hive/gha-npm-cache@v1
-      # - uses: samuelmeuli/action-snapcraft@v1
-      #   if: startsWith(matrix.os, 'ubuntu')
-      #   with:
-      #     snapcraft_token: ${{ secrets.snapcraft_token }}
+      - uses: samuelmeuli/action-snapcraft@v1
+        if: startsWith(matrix.os, 'ubuntu')
+        with:
+          snapcraft_token: ${{ secrets.snapcraft_token }}
       - uses: samuelmeuli/action-electron-builder@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
 		"linux": {
 			"target": [
 				"AppImage",
-				"deb"
+				"deb",
+				"snap"
 			],
 			"icon": "build/icons/",
 			"synopsis": "Elegant Facebook Messenger desktop app",


### PR DESCRIPTION
I have access to the snap package on the snap store and have managed to manually publish the latest version. I however don't have access to change the access token for ci so I will either need that access in this repo or I could send Sindre the token somehow so he can add it himself.

// @sindresorhus 