### PR TITLE
Add maintainers in about dialog

### DIFF
--- a/source/menu.ts
+++ b/source/menu.ts
@@ -729,6 +729,7 @@ ${debugInfo()}`;
 			aboutMenuItem({
 				icon: caprineIconPath,
 				copyright: 'Created by Sindre Sorhus',
+				text: "Maintainers:\nDušan Simić\nLefteris Garyfalakis\nNikolas Spiridakis",
 				website: 'https://sindresorhus.com/caprine',
 			}),
 		);

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -729,7 +729,7 @@ ${debugInfo()}`;
 			aboutMenuItem({
 				icon: caprineIconPath,
 				copyright: 'Created by Sindre Sorhus',
-				text: "Maintainers:\nDušan Simić\nLefteris Garyfalakis\nNikolas Spiridakis",
+				text: 'Maintainers:\nDušan Simić\nLefteris Garyfalakis\nNikolas Spiridakis',
 				website: 'https://sindresorhus.com/caprine',
 			}),
 		);

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -729,7 +729,7 @@ ${debugInfo()}`;
 			aboutMenuItem({
 				icon: caprineIconPath,
 				copyright: 'Created by Sindre Sorhus',
-				text: 'Maintainers:\nDušan Simić\nLefteris Garyfalakis\nNikolas Spiridakis',
+				text: 'Maintainers:\nDušan Simić\nLefteris Garyfalakis\nMichael Quevillon\nNikolas Spiridakis',
 				website: 'https://sindresorhus.com/caprine',
 			}),
 		);


### PR DESCRIPTION
Adds maintainers' names in the about dialog (Help -> About Caprine). Resolves #1873.

A text parameter I found in electron-util is used to store the text. However, this should only be temporary as the about dialog in general needs to be improved.

![εικόνα](https://user-images.githubusercontent.com/46350667/183295058-f5c85f73-085a-4c77-b0ed-3a7e3c8c7a0b.png)
