### PR TITLE
Set window title to "Caprine"

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -442,6 +442,9 @@ function createMainWindow(): BrowserWindow {
 	const {webContents} = mainWindow;
 
 	webContents.on('dom-ready', async () => {
+		// Set window title to Caprine
+		mainWindow.setTitle(app.name);
+
 		const isNewDesign = await ipcMain.callRenderer<undefined, boolean>(mainWindow, 'check-new-ui');
 
 		await updateAppMenu({isNewDesign});


### PR DESCRIPTION
I have noticed that by default, messenger.com overrides the window title and sets it to "Messenger". Wouldn't it be better if it was set to "Caprine"?

![εικόνα](https://user-images.githubusercontent.com/46350667/186170920-dc7a677f-e9cc-4b60-8056-53ee2a142083.png)