### PR TITLE
Fix custom css default file

### DIFF
--- a/source/menu.ts
+++ b/source/menu.ts
@@ -210,29 +210,8 @@ This is the custom styles file where you can add anything you want.
 The styles here will be injected into Caprine and will override default styles.
 If you want to disable styles but keep the config, just comment the lines that you don't want to be used.
 
-Here are some dark mode color variables to get you started.
-Edit them to change color scheme of Caprine.
 Press Command/Ctrl+R in Caprine to see your changes.
 */
-
-:root {
-	--base: #000;
-	--base-ninety: rgba(255, 255, 255, 0.9);
-	--base-seventy-five: rgba(255, 255, 255, 0.75);
-	--base-seventy: rgba(255, 255, 255, 0.7);
-	--base-fifty: rgba(255, 255, 255, 0.5);
-	--base-fourty: rgba(255, 255, 255, 0.4);
-	--base-thirty: rgba(255, 255, 255, 0.3);
-	--base-twenty: rgba(255, 255, 255, 0.2);
-	--base-five: rgba(255, 255, 255, 0.05);
-	--base-ten: rgba(255, 255, 255, 0.1);
-	--base-nine: rgba(255, 255, 255, 0.09);
-	--container-color: #323232;
-	--container-dark-color: #1e1e1e;
-	--list-header-color: #222;
-	--blue: #0084ff;
-	--selected-conversation-background: linear-gradient(hsla(209, 110%, 45%, 0.9), hsla(209, 110%, 42%, 0.9));
-}
 `;
 
 				if (!existsSync(filePath)) {


### PR DESCRIPTION
Default file for custom css contained color scheme variables for old design. This caused some confusion which lead to users thinking the custom styles didn't load. I'm proposing a fix which is just removing those variables. Users can create a custom color scheme by copying css variables from Messenger website and putting them in custom css file and modifying them.

Closes: #1900