### PR TITLE
Exclude /usr/lib/.build-id/ from generated package

### DIFF
--- a/packages/rpm/caprine.spec
+++ b/packages/rpm/caprine.spec
@@ -1,4 +1,5 @@
 %define debug_package %{nil}
+%global _build_id_links alldebug
 
 Name:           caprine
 Version:        2.57.0


### PR DESCRIPTION
When trying to install caprine I got:
```
Error: Transaction test error:
  file /usr/lib/.build-id/0d/9fad3f21b1e381cc66b5efcae8f3910ae0edc1 from install of caprine-2.57.0-1.fc37.x86_64 conflicts with file from package slack-4.29.149-0.1.el8.x86_64
  file /usr/lib/.build-id/76/9d0269491ca2313fcd15d63059bac67bd8b1b3 from install of caprine-2.57.0-1.fc37.x86_64 conflicts with file from package slack-4.29.149-0.1.el8.x86_64
  file /usr/lib/.build-id/c2/dcac7cb6a727685d10d4161a0d14988f12a0fa from install of caprine-2.57.0-1.fc37.x86_64 conflicts with file from package slack-4.29.149-0.1.el8.x86_64
  file /usr/lib/.build-id/cb/dc9db5fec0e6129bddcb0c282be98be4c6966e from install of caprine-2.57.0-1.fc37.x86_64 conflicts with file from package slack-4.29.149-0.1.el8.x86_64
```
According to https://bugzilla.redhat.com/show_bug.cgi?id=1820370#c1 we can move the build-id links to debuginfo packages with this in the spec:

%global _build_id_links alldebug

I added it to the spec file, rebuilt the package, and the only difference is that `/usr/lib/.build-id/*` are not included.
CC @dusansimic 