### PR TITLE
Add Apple Silicon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn.lock
 /dist-js
 mas.provisionprofile
 .vscode
+.DS_store

--- a/package.json
+++ b/package.json
@@ -108,8 +108,12 @@
 		"mac": {
 			"category": "public.app-category.social-networking",
 			"icon": "build/icon.png",
-			"electronUpdaterCompatibility": ">=2.15.0",
+			"electronUpdaterCompatibility": ">=4.5.2",
 			"darkModeSupport": true,
+			"target": {
+				"target": "default",
+				"arch": ["x64", "arm64"]
+			},
 			"extendInfo": {
 				"LSUIElement": 1,
 				"NSCameraUsageDescription": "Caprine needs access to your camera.",

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@
 
 ## Install
 
-*macOS 10.10+, Linux, and Windows 10+ are supported (64-bit only).*
+*macOS 10.12+ (Intel and Apple Silicon), Linux (x86 and arm64), and Windows 10+ (64-bit) are supported.*
 
 Download the latest version on the [website](https://sindresorhus.com/caprine) or below.
 

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@
 
 ## Install
 
-*macOS 10.12+ (Intel and Apple Silicon), Linux (x86 and arm64), and Windows 10+ (64-bit) are supported.*
+*macOS 10.12+ (Intel and Apple Silicon), Linux (x64 and arm64), and Windows 10+ (64-bit) are supported.*
 
 Download the latest version on the [website](https://sindresorhus.com/caprine) or below.
 


### PR DESCRIPTION
This patch adds Apple Silicon support.

Electron Updater compatibility version is bumped because of this [issue](https://github.com/electron-userland/electron-builder/issues/5689). In the long run we should probably switch to Electron Forge.

Closes: #1975