### PR TITLE
Workaround for electron-store in renderer

### DIFF
--- a/source/autoplay.ts
+++ b/source/autoplay.ts
@@ -1,11 +1,12 @@
-import config from './config';
+import {ipcRenderer as ipc} from 'electron-better-ipc';
 import selectors from './browser/selectors';
 
 const conversationId = 'conversationWindow';
 const disabledVideoId = 'disabled_autoplay';
 
-export function toggleVideoAutoplay(): void {
-	if (config.get('autoplayVideos')) {
+export async function toggleVideoAutoplay(): Promise<void> {
+	const autoplayVideos = await ipc.callMain<undefined, boolean>('get-config-autoplayVideos');
+	if (autoplayVideos) {
 		// Stop the observers
 		conversationDivObserver.disconnect();
 		videoObserver.disconnect();

--- a/source/config.ts
+++ b/source/config.ts
@@ -1,7 +1,8 @@
 import Store from 'electron-store';
 import {is} from 'electron-util';
+import {EmojiStyle} from './emoji';
 
-type StoreType = {
+export type StoreType = {
 	theme: 'system' | 'light' | 'dark';
 	privateMode: boolean;
 	showPrivateModePrompt: boolean;
@@ -30,7 +31,7 @@ type StoreType = {
 		typingIndicator: boolean;
 		deliveryReceipt: boolean;
 	};
-	emojiStyle: 'native' | 'facebook-3-0' | 'messenger-1-0' | 'facebook-2-2';
+	emojiStyle: EmojiStyle;
 	useWorkChat: boolean;
 	sidebar: 'default' | 'hidden' | 'narrow' | 'wide';
 	autoHideMenuBar: boolean;

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -8,8 +8,8 @@ import {
 } from 'electron';
 import {is} from 'electron-util';
 import {memoize} from 'lodash';
-import config from './config';
 import {showRestartDialog, getWindow, sendBackgroundAction} from './util';
+import config from './config';
 
 // The list of emojis that aren't supported by older emoji (facebook-2-2, messenger-1-0)
 // Based on https://emojipedia.org/facebook/3.0/new/
@@ -298,7 +298,7 @@ with this: https://static.xx.fbcdn.net/images/emoji.php/v9/z27/2/32/1f600.png
                                                  (see here) ^
 */
 export async function process(url: string): Promise<CallbackResponse> {
-	const emojiStyle = config.get('emojiStyle') as EmojiStyle;
+	const emojiStyle = config.get('emojiStyle');
 	const emojiSetCode = codeForEmojiStyle(emojiStyle);
 
 	// The character code is the filename without the extension.


### PR DESCRIPTION
This patch removes use of [electron-store](https://github.com/sindresorhus/electron-store) package from renderer process. For some reason, today electron-store decided to cause trouble (specifically its dependency, [ajv](https://github.com/ajv-validator/ajv)) in the renderer process so using IPC calls, I've moved all its use-cases to the main process.

Closes: #2036