### PR TITLE
Hidden dialogue fix

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -645,13 +645,15 @@ async function closePreferences(): Promise<void> {
 			preferencesOverlayObserver.disconnect();
 		}
 	});
-
 	const preferencesOverlay = document.querySelector(selectors.preferencesSelector)!;
 
-	preferencesOverlayObserver.observe(preferencesOverlay, {childList: true});
+	// Get the parent of preferences, that's not getting deleted
+	const preferencesParent = preferencesOverlay.closest('div:not([class])')!;
 
-	const closeButton = await elementReady<HTMLElement>(selectors.closePreferencesButton, {stopOnDomReady: false});
-	closeButton?.click();
+	preferencesOverlayObserver.observe(preferencesParent, {childList: true});
+
+	const closeButton = preferencesOverlay.querySelector(selectors.closePreferencesButton)!;
+	(closeButton as HTMLElement)?.click();
 }
 
 function insertionListener(event: AnimationEvent): void {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -645,6 +645,7 @@ async function closePreferences(): Promise<void> {
 			preferencesOverlayObserver.disconnect();
 		}
 	});
+
 	const preferencesOverlay = document.querySelector(selectors.preferencesSelector)!;
 
 	// Get the parent of preferences, that's not getting deleted

--- a/source/browser/selectors.ts
+++ b/source/browser/selectors.ts
@@ -6,12 +6,12 @@ export default {
 	rightSidebarSegments: '.oajrlxb2.gs1a9yip.g5ia77u1.mtkw9kbi.tlpljxtp.qensuy8j.ppp5ayq2.goun2846.ccm00jje.s44p3ltw.mk2mc5f4.rt8b4zig.n8ej3o3l.agehan2d.sk4xxmp2.rq0escxv.nhd2j8a9.mg4g778l.pfnyh3mw.p7hjln8o.kvgmc6g5.cxmmr5t8.oygrvhab.hcukyx3x.tgvbjcpo.hpfvmrgz.jb3vyjys.rz4wbd8a.qt6c0cv9.a8nywdso.l9j0dhe7.i1ao9s8h.esuyzwwr.f1sip0of.du4w35lb.btwxx1t3.abiwlrkh.p8dawk7l.j83agx80.lzcic4wl.beltcj47.p86d2i9g.aot14ch1.kzx2olss',
 	muteIconNewDesign: 'path[d="M29.676 7.746c.353-.352.44-.92.15-1.324a1 1 0 00-1.524-.129L6.293 28.29a1 1 0 00.129 1.523c.404.29.972.204 1.324-.148l3.082-3.08A2.002 2.002 0 0112.242 26h15.244c.848 0 1.57-.695 1.527-1.541-.084-1.643-1.87-1.145-2.2-3.515l-1.073-8.157-.002-.01a1.976 1.976 0 01.562-1.656l3.376-3.375zm-9.165 20.252H15.51c-.313 0-.565.275-.506.575.274 1.38 1.516 2.422 3.007 2.422 1.49 0 2.731-1.042 3.005-2.422.06-.3-.193-.575-.505-.575zm-10.064-6.719L22.713 9.02a.997.997 0 00-.124-1.51 7.792 7.792 0 00-12.308 5.279l-1.04 7.897c-.089.672.726 1.074 1.206.594z"]',
 	// ! Very fragile selector (most likely cause of hidden dialog issue)
-	closePreferencesButton: 'div[role=dialog] .x92rtbv.x10l6tqk.xomnu4r.x1vjfegm div[role=button]',
+	closePreferencesButton: 'div[role=dialog] [class="x9f619 x1n2onr6 x1ja2u2z"] div[role=button]',
 	userMenu: '.qi72231t.o9w3sbdw.nu7423ey.tav9wjvu.flwp5yud.tghlliq5.gkg15gwv.s9ok87oh.s9ljgwtm.lxqftegz.bf1zulr9.frfouenu.bonavkto.djs4p424.r7bn319e.bdao358l.fsf7x5fv.tgm57n0e.jez8cy9q.s5oniofx.m8h3af8h.l7ghb35v.kjdc1dyq.kmwttqpk.dnr7xe2t.aeinzg81.srn514ro.oxkhqvkx.rl78xhln.nch0832m.om3e55n1.cr00lzj9.rn8ck1ys.s3jn8y49.g4tp4svg.o9erhkwx.dzqi5evh.hupbnkgi.hvb2xoa8.fxk3tzhb.jl2a5g8c.f14ij5to.l3ldwz01.icdlwmnq > .aglvbi8b.om3e55n1.i8zpp7h3.g4tp4svg',
 	userMenuNewSidebar: '[role=navigation] [role=button]',
 	selectedConversation: '[role=navigation] [role=grid] [role=row] [role=gridcell] [role=link][aria-current]',
 	// ! Very fragile selector (most likely cause of hidden dialog issue)
-	preferencesSelector: 'div[class="x78zum5 xdt5ytf xg6iff7 x1n2onr6 xwnxf6m"]',
+	preferencesSelector: 'div[role=dialog][class="x1n2onr6 x1ja2u2z x1afcbsf x78zum5 xdt5ytf x1a2a7pz x6ikm8r x10wlt62 x71s49j x1jx94hy xyi19xy x1ccrb07 xtf3nb5 x1pc53ja x104qc98 x1g2kw80 x16n5opg xl7ujzl xhkep3z xeb55yp x17omtbh"]',
 	// TODO: Fix this selector for new design
 	messengerSoundsSelector: '._374d ._6bkz',
 	conversationMenuSelectorNewDesign: '[role=menu]',


### PR DESCRIPTION
There's a recent issue where no dialog is displayed(related to pr #2006). This pr updates the preferences selectors, and also changes the `closePreferences` function to properly remove the `hide-preferences-window` class, when the preferences overlay is closed.

Fixes #2055
Fixes #2054 