### PR TITLE
Apply dark mode coloring to Privacy & safety in settings

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -157,6 +157,12 @@ html.dark-mode ._9xq0 {
 	color: var(--primary-text);
 }
 
+/* Messenger settings: Privacy & safety icon color */
+.x1lliihq.x1k90msu.x2h7rmj.x1qfuztq.x198g3q0.xxk0z11.xvy4d1p {
+	fill: currentcolor;
+	color: var(--primary-text);
+}
+
 /* Removing top gap */
 /* TODO: Remove when fixed by fb */
 .__fb-dark-mode {


### PR DESCRIPTION
Minor dark mode change to "Privacy & safety" item in Messenger settings

![image](https://github.com/sindresorhus/caprine/assets/17033543/ae376bd1-0ef3-4b9b-abfe-060274ff2616)
fixed to 
![image](https://github.com/sindresorhus/caprine/assets/17033543/c17ea184-16a2-466c-8470-0846977dc7b8)
