### PR TITLE
Use more specific  CSS selector for Search results Close button

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -189,8 +189,8 @@ html.dark-mode .x1n2onr6.x1ja2u2z.x78zum5.x2lah0s.xl56j7k.x6s0dn4.xozqiw3.x1q0g3
 
 /* Search results: Close button */
 /* TODO: Remove when fixed by fb, since --always-white is not good here */
-html.dark-mode .x14hiurz {
-	background-color: transparent !important;
+html.dark-mode .x14hiurz.x1r1pt67 {
+	background-color: var(--secondary-button-background) !important;
 }
 
 /* Attachment background color in Chat Box */


### PR DESCRIPTION
The previous selector (`.x14hiurz`) was not specific enough for the search results "Close" button, since it also affected preferences selectors below.

![image](https://github.com/sindresorhus/caprine/assets/17033543/ef306b3d-8b73-4f2f-9698-856385e4e1ca)
![image](https://github.com/sindresorhus/caprine/assets/17033543/193e0a13-77f0-48d8-b58f-986b7a758e0b)

The color is updated so the "Close" actually looks like a clickable button and no longer affects the preferences checkboxes.

![image](https://github.com/sindresorhus/caprine/assets/17033543/979fc809-5eaa-462f-975c-60d8365011ea)
![image](https://github.com/sindresorhus/caprine/assets/17033543/f206321b-72a5-43da-8dd0-9c603b01cfb5)

(I think I'd like *more* contrast on the checkboxes from a design perspective, but am reverting to default styles for now.)