### PR TITLE
Verify that notificationCheckbox is non-null

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -272,6 +272,11 @@ ipc.answerMain('toggle-mute-notifications', async () => {
 		await closePreferences();
 	}
 
+	// TODO: Fix notifications
+	if (notificationCheckbox === null) {
+		return false;
+	}
+
 	return !notificationCheckbox.checked;
 });
 


### PR DESCRIPTION
Since the notifications are currently somewhat broken, this is a temporary patch that returns `false` if the selector is null. I would be wary of simply toggling the "Do not disturb" mode, since it normally sets a time limit for that mode, which may require more of an overhaul of notification options. I'm open to handling this differently, but it does handle this promise/error.

The error on the current version:
```
(node:10656) UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of null (reading 'checked')
    at ...\caprine\dist-js\browser.js:208:34
    at async EventEmitter.listener (...\caprine\node_modules\electron-better-ipc\source\renderer.js:46:34)
```