### PR TITLE
Select views for new sidebar

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -87,9 +87,25 @@ async function selectOtherListViews(itemNumber: number): Promise<void> {
 	// In case one of other views is shown
 	clickBackButton();
 
-	await withSettingsMenu(() => {
-		selectMenuItem(itemNumber);
-	});
+	const newSidebar = await isNewSidebar();
+
+	if (newSidebar) {
+		const items = document.querySelectorAll<HTMLElement>(
+			`${selectors.viewsMenu} > span > a`
+		);
+
+		const selector = itemNumber <= items.length ? items[itemNumber - 1] : null;
+
+		console.log(selector);
+
+		if (selector) {
+			selector.click();
+		}
+	} else {
+		await withSettingsMenu(() => {
+			selectMenuItem(itemNumber);
+		});
+	}
 }
 
 function clickBackButton(): void {
@@ -280,20 +296,24 @@ ipc.answerMain('toggle-message-buttons', async () => {
 	document.body.classList.toggle('show-message-buttons', !showMessageButtons);
 });
 
-ipc.answerMain('show-active-contacts-view', async () => {
+ipc.answerMain('show-chats-view', async () => {
+	await selectOtherListViews(1);
+});
+
+ipc.answerMain('show-people-view', async () => {
 	await selectOtherListViews(2);
 });
 
-ipc.answerMain('show-message-requests-view', async () => {
+ipc.answerMain('show-marketplace-view', async () => {
 	await selectOtherListViews(3);
 });
 
-ipc.answerMain('show-hidden-threads-view', async () => {
+ipc.answerMain('show-requests-view', async () => {
 	await selectOtherListViews(4);
 });
 
-ipc.answerMain('toggle-unread-threads-view', async () => {
-	await selectOtherListViews(6);
+ipc.answerMain('show-archive-view', async () => {
+	await selectOtherListViews(5);
 });
 
 ipc.answerMain('toggle-video-autoplay', () => {

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -91,7 +91,7 @@ async function selectOtherListViews(itemNumber: number): Promise<void> {
 
 	if (newSidebar) {
 		const items = document.querySelectorAll<HTMLElement>(
-			`${selectors.viewsMenu} > span > a`
+			`${selectors.viewsMenu} > span > a`,
 		);
 
 		const selector = itemNumber <= items.length ? items[itemNumber - 1] : null;

--- a/source/browser/selectors.ts
+++ b/source/browser/selectors.ts
@@ -11,6 +11,7 @@ export default {
 	closePreferencesButton: 'div[role=dialog] [class="x9f619 x1n2onr6 x1ja2u2z"] div[role=button]',
 	userMenu: '.qi72231t.o9w3sbdw.nu7423ey.tav9wjvu.flwp5yud.tghlliq5.gkg15gwv.s9ok87oh.s9ljgwtm.lxqftegz.bf1zulr9.frfouenu.bonavkto.djs4p424.r7bn319e.bdao358l.fsf7x5fv.tgm57n0e.jez8cy9q.s5oniofx.m8h3af8h.l7ghb35v.kjdc1dyq.kmwttqpk.dnr7xe2t.aeinzg81.srn514ro.oxkhqvkx.rl78xhln.nch0832m.om3e55n1.cr00lzj9.rn8ck1ys.s3jn8y49.g4tp4svg.o9erhkwx.dzqi5evh.hupbnkgi.hvb2xoa8.fxk3tzhb.jl2a5g8c.f14ij5to.l3ldwz01.icdlwmnq > .aglvbi8b.om3e55n1.i8zpp7h3.g4tp4svg',
 	userMenuNewSidebar: '[role=navigation] [role=button]',
+	viewsMenu: '.x9f619.x1n2onr6.x1ja2u2z.x78zum5.xdt5ytf.x2lah0s.x193iq5w.xurb0ha.x1sxyh0.xdj266r',
 	selectedConversation: '[role=navigation] [role=grid] [role=row] [role=gridcell] [role=link][aria-current]',
 	// ! Very fragile selector (most likely cause of hidden dialog issue)
 	preferencesSelector: 'div[role=dialog][class="x1n2onr6 x1ja2u2z x1afcbsf x78zum5 xdt5ytf x1a2a7pz x6ikm8r x10wlt62 x71s49j x1jx94hy xyi19xy x1ccrb07 xtf3nb5 x1pc53ja x104qc98 x1g2kw80 x16n5opg xl7ujzl xhkep3z xeb55yp x17omtbh"]',

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -537,21 +537,33 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			type: 'separator',
 		},
 		{
+			label: 'Show Main Chats',
+			click() {
+				sendAction('show-chats-view');
+			},
+		},
+		{
 			label: 'Show Active Contacts',
 			click() {
-				sendAction('show-active-contacts-view');
+				sendAction('show-people-view');
+			},
+		},
+		{
+			label: 'Show Marketplace Chats',
+			click() {
+				sendAction('show-marketplace-view');
 			},
 		},
 		{
 			label: 'Show Message Requests',
 			click() {
-				sendAction('show-message-requests-view');
+				sendAction('show-requests-view');
 			},
 		},
 		{
-			label: 'Show Hidden Threads',
+			label: 'Show Archived Chats',
 			click() {
-				sendAction('show-hidden-threads-view');
+				sendAction('show-archive-view');
 			},
 		},
 	];


### PR DESCRIPTION
I'm not sure if it's safe to assume that (most) people have the new sidebar at this point, or if we should retain past compatibility. This should allow for selecting view through the View menu, if users want to select it that way.

I renamed the actions to reflect what Messenger calls the different views as well.

I am very open to any suggestions about how this should be handled or adjusted as needed.

Fixes #1984.