### PR TITLE
Set top limit for electron version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/facebook-locales": "^1.0.0",
 				"@types/lodash": "^4.14.182",
 				"del-cli": "^5.0.0",
-				"electron": ">=24.8.3",
+				"electron": ">=24.8.3 < 25.0.0",
 				"electron-builder": "^23.4.0",
 				"husky": "^8.0.1",
 				"np": "^7.6.2",
@@ -3275,9 +3275,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "26.2.2",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-26.2.2.tgz",
-			"integrity": "sha512-Ihb3Zt4XYnHF52DYSq17ySkgFqJV4OT0VnfhUYZASAql7Vembz3VsAq7mB3OALBHXltAW34P8BxTIwTqZaMS3g==",
+			"version": "24.8.3",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-24.8.3.tgz",
+			"integrity": "sha512-6YTsEOIMIQNnOz0Fj5gAWtwCuDd66iYKkuRJGyc80jKKYI49jBeH+R7ZZry9uiVu4T4bZgBN2FAN24XfCioQZA==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@electron/get": "^2.0.0",
@@ -17437,9 +17437,9 @@
 			}
 		},
 		"electron": {
-			"version": "26.2.2",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-26.2.2.tgz",
-			"integrity": "sha512-Ihb3Zt4XYnHF52DYSq17ySkgFqJV4OT0VnfhUYZASAql7Vembz3VsAq7mB3OALBHXltAW34P8BxTIwTqZaMS3g==",
+			"version": "24.8.3",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-24.8.3.tgz",
+			"integrity": "sha512-6YTsEOIMIQNnOz0Fj5gAWtwCuDd66iYKkuRJGyc80jKKYI49jBeH+R7ZZry9uiVu4T4bZgBN2FAN24XfCioQZA==",
 			"requires": {
 				"@electron/get": "^2.0.0",
 				"@types/node": "^18.11.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/facebook-locales": "^1.0.0",
 				"@types/lodash": "^4.14.182",
 				"del-cli": "^5.0.0",
-				"electron": ">=24.8.3 < 25.0.0",
+				"electron": ">=24.8.3 <25.0.0",
 				"electron-builder": "^23.4.0",
 				"husky": "^8.0.1",
 				"np": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@types/facebook-locales": "^1.0.0",
 		"@types/lodash": "^4.14.182",
 		"del-cli": "^5.0.0",
-		"electron": ">=24.8.3",
+		"electron": ">=24.8.3 < 25.0.0",
 		"electron-builder": "^23.4.0",
 		"husky": "^8.0.1",
 		"np": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@types/facebook-locales": "^1.0.0",
 		"@types/lodash": "^4.14.182",
 		"del-cli": "^5.0.0",
-		"electron": ">=24.8.3 < 25.0.0",
+		"electron": ">=24.8.3 <25.0.0",
 		"electron-builder": "^23.4.0",
 		"husky": "^8.0.1",
 		"np": "^7.6.2",


### PR DESCRIPTION
This patch sets a top limit for Electron version (so it's `>=24.8.3` but still remains v24). This resolves the issues with dark theme not working.

Closes: #2072
Closes: #2071


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2074: I see the Messenger login screen then in a few seconds the window turns white](https://oss.issuehunt.io/repos/42574339/issues/2074)
- [#95: Strange new message icon behaviour in tray with Linux](https://oss.issuehunt.io/repos/42574339/issues/95)
---
</details>
<!-- /Issuehunt content-->