### PR TITLE
Bump Electron version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron/remote": "^2.0.8",
+				"@electron/remote": "^2.0.12",
 				"@sindresorhus/do-not-disturb": "^1.1.0",
 				"electron-better-ipc": "^2.0.1",
 				"electron-context-menu": "^3.4.0",
@@ -34,7 +34,7 @@
 				"@types/facebook-locales": "^1.0.0",
 				"@types/lodash": "^4.14.182",
 				"del-cli": "^5.0.0",
-				"electron": "^24.8.5",
+				"electron": "^26.4.0",
 				"electron-builder": "^23.4.0",
 				"husky": "^8.0.1",
 				"np": "^7.6.2",
@@ -343,9 +343,9 @@
 			}
 		},
 		"node_modules/@electron/remote": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.8.tgz",
-			"integrity": "sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.12.tgz",
+			"integrity": "sha512-IJN6xLAxptq5MCvXNCU6+pdQyz0DjpPtX6g2TPJftu3Z9pU6BTdnos9ZMN8nK471LkASqiA6C+Hzjv5SS8PAQw==",
 			"peerDependencies": {
 				"electron": ">= 13.0.0"
 			}
@@ -3275,9 +3275,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "24.8.6",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-24.8.6.tgz",
-			"integrity": "sha512-OIwFfQI6srMwwH3K1nKO8ix6HaK7liB5QJYSaW8bMnhJcqwbHKk097jZmp355FaT3+zRYpHr+SnIUFINCpy7JQ==",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-26.4.0.tgz",
+			"integrity": "sha512-FUEFwmIlflLxImRtTmDp8CWpH4KqlyAwga6vauaz6+882SmyC3bJRhgqOIT5s6rMbW25WezNiaqfKqHDJjz3pw==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@electron/get": "^2.0.0",
@@ -15182,9 +15182,9 @@
 			}
 		},
 		"@electron/remote": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.8.tgz",
-			"integrity": "sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.12.tgz",
+			"integrity": "sha512-IJN6xLAxptq5MCvXNCU6+pdQyz0DjpPtX6g2TPJftu3Z9pU6BTdnos9ZMN8nK471LkASqiA6C+Hzjv5SS8PAQw==",
 			"requires": {}
 		},
 		"@electron/universal": {
@@ -17437,9 +17437,9 @@
 			}
 		},
 		"electron": {
-			"version": "24.8.6",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-24.8.6.tgz",
-			"integrity": "sha512-OIwFfQI6srMwwH3K1nKO8ix6HaK7liB5QJYSaW8bMnhJcqwbHKk097jZmp355FaT3+zRYpHr+SnIUFINCpy7JQ==",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-26.4.0.tgz",
+			"integrity": "sha512-FUEFwmIlflLxImRtTmDp8CWpH4KqlyAwga6vauaz6+882SmyC3bJRhgqOIT5s6rMbW25WezNiaqfKqHDJjz3pw==",
 			"requires": {
 				"@electron/get": "^2.0.0",
 				"@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"release": "np"
 	},
 	"dependencies": {
-		"@electron/remote": "^2.0.8",
+		"@electron/remote": "^2.0.12",
 		"@sindresorhus/do-not-disturb": "^1.1.0",
 		"electron-better-ipc": "^2.0.1",
 		"electron-context-menu": "^3.4.0",
@@ -47,7 +47,7 @@
 		"@types/facebook-locales": "^1.0.0",
 		"@types/lodash": "^4.14.182",
 		"del-cli": "^5.0.0",
-		"electron": "^24.8.5",
+		"electron": "^26.4.0",
 		"electron-builder": "^23.4.0",
 		"husky": "^8.0.1",
 		"np": "^7.6.2",


### PR DESCRIPTION
Electron 24 is EOL. This patch bumps Electron to 26 and also the `@electron/remote` module so it's compatible with new Electron version.