### PR TITLE
Upgrade element-ready to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"electron-store": "^8.1.0",
 				"electron-updater": "^5.2.1",
 				"electron-util": "^0.17.2",
-				"element-ready": "^5.0.0",
+				"element-ready": "^7.0.0",
 				"facebook-locales": "^1.0.916",
 				"is-online": "^9.0.1",
 				"json-schema-typed": "^8.0.1",
@@ -2960,6 +2960,29 @@
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
 			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
+		"node_modules/deferred-async-iterator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/deferred-async-iterator/-/deferred-async-iterator-3.0.0.tgz",
+			"integrity": "sha512-VEWY9Cwv4LkWHDl7cAwMDisj0Y3n/D9tAJynuuzxA3s14Wg8z69yACbKWt/dBBfvmUbu6wa6ea3W7E6adRHx1A==",
+			"dependencies": {
+				"p-defer": "^4.0.0",
+				"yocto-queue": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/deferred-async-iterator/node_modules/yocto-queue": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -3638,15 +3661,20 @@
 			}
 		},
 		"node_modules/element-ready": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/element-ready/-/element-ready-5.0.0.tgz",
-			"integrity": "sha512-eKSRBkCaYhxQgxb1Lray3pV8sstpleUTQF1vNMXXb+hu05reDhIZYQdqygBnS/M7LbvdSPZ6AwG/LYpPmlKU6A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/element-ready/-/element-ready-7.0.0.tgz",
+			"integrity": "sha512-PuyQkIQPxgEmHZA3WmiKBhvnbCUybsIUhW3+7WSglmN746IljgVfPVJOq4PYdj5lh2LSnPDe8aSfb/cXK50mbQ==",
 			"dependencies": {
-				"many-keys-map": "^1.0.3",
-				"p-defer": "^3.0.0"
+				"deferred-async-iterator": "^3.0.0",
+				"many-keys-map": "^2.0.1",
+				"p-defer": "^4.0.0",
+				"typed-query-selector": "^2.11.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/element-ready?sponsor=1"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -7994,9 +8022,12 @@
 			}
 		},
 		"node_modules/many-keys-map": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-1.0.3.tgz",
-			"integrity": "sha512-Iguobalgc8YO1kbN1U9R/j6u3QFf6bwIh37HKYFgEtUJNJd79INgLwtdiiOgBPoBqZ/ZVc4zziRaVg0EiJ+82g=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-2.0.1.tgz",
+			"integrity": "sha512-DHnZAD4phTbZ+qnJdjoNEVU1NecYoSdbOOoVmTDH46AuxDkEVh3MxTVpXq10GtcTC6mndN9dkv1rNfpjRcLnOw==",
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
 		},
 		"node_modules/map-age-cleaner": {
 			"version": "0.1.3",
@@ -10643,11 +10674,14 @@
 			}
 		},
 		"node_modules/p-defer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+			"integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-event": {
@@ -13405,6 +13439,11 @@
 			"optionalDependencies": {
 				"rxjs": "*"
 			}
+		},
+		"node_modules/typed-query-selector": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.0.tgz",
+			"integrity": "sha512-qBs4sfmnLlPOyo2oSdvHbIFHe2CPgU54/1UGfSNceb7LARpIEVxUaeRX0Doje6oKpuySS2stqy90R3YrynR8Kg=="
 		},
 		"node_modules/typedarray-to-buffer": {
 			"version": "3.1.5",
@@ -17207,6 +17246,22 @@
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
 			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
+		"deferred-async-iterator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/deferred-async-iterator/-/deferred-async-iterator-3.0.0.tgz",
+			"integrity": "sha512-VEWY9Cwv4LkWHDl7cAwMDisj0Y3n/D9tAJynuuzxA3s14Wg8z69yACbKWt/dBBfvmUbu6wa6ea3W7E6adRHx1A==",
+			"requires": {
+				"p-defer": "^4.0.0",
+				"yocto-queue": "^1.0.0"
+			},
+			"dependencies": {
+				"yocto-queue": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
+				}
+			}
+		},
 		"define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -17733,12 +17788,14 @@
 			"dev": true
 		},
 		"element-ready": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/element-ready/-/element-ready-5.0.0.tgz",
-			"integrity": "sha512-eKSRBkCaYhxQgxb1Lray3pV8sstpleUTQF1vNMXXb+hu05reDhIZYQdqygBnS/M7LbvdSPZ6AwG/LYpPmlKU6A==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/element-ready/-/element-ready-7.0.0.tgz",
+			"integrity": "sha512-PuyQkIQPxgEmHZA3WmiKBhvnbCUybsIUhW3+7WSglmN746IljgVfPVJOq4PYdj5lh2LSnPDe8aSfb/cXK50mbQ==",
 			"requires": {
-				"many-keys-map": "^1.0.3",
-				"p-defer": "^3.0.0"
+				"deferred-async-iterator": "^3.0.0",
+				"many-keys-map": "^2.0.1",
+				"p-defer": "^4.0.0",
+				"typed-query-selector": "^2.11.0"
 			}
 		},
 		"emoji-regex": {
@@ -20979,9 +21036,9 @@
 			}
 		},
 		"many-keys-map": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-1.0.3.tgz",
-			"integrity": "sha512-Iguobalgc8YO1kbN1U9R/j6u3QFf6bwIh37HKYFgEtUJNJd79INgLwtdiiOgBPoBqZ/ZVc4zziRaVg0EiJ+82g=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-2.0.1.tgz",
+			"integrity": "sha512-DHnZAD4phTbZ+qnJdjoNEVU1NecYoSdbOOoVmTDH46AuxDkEVh3MxTVpXq10GtcTC6mndN9dkv1rNfpjRcLnOw=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -22833,9 +22890,9 @@
 			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
 		},
 		"p-defer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+			"integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
 		},
 		"p-event": {
 			"version": "4.2.0",
@@ -24829,6 +24886,11 @@
 			"requires": {
 				"rxjs": "*"
 			}
+		},
+		"typed-query-selector": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.0.tgz",
+			"integrity": "sha512-qBs4sfmnLlPOyo2oSdvHbIFHe2CPgU54/1UGfSNceb7LARpIEVxUaeRX0Doje6oKpuySS2stqy90R3YrynR8Kg=="
 		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"electron-store": "^8.1.0",
 		"electron-updater": "^5.2.1",
 		"electron-util": "^0.17.2",
-		"element-ready": "^5.0.0",
+		"element-ready": "^7.0.0",
 		"facebook-locales": "^1.0.916",
 		"is-online": "^9.0.1",
 		"json-schema-typed": "^8.0.1",

--- a/source/browser-call.ts
+++ b/source/browser-call.ts
@@ -1,7 +1,7 @@
 import elementReady from 'element-ready';
 
 (async () => {
-	const startCallButton = (await elementReady<HTMLElement>('._3quh._30yy._2t_', {
+	const startCallButton = (await elementReady('._3quh._30yy._2t_', {
 		stopOnDomReady: false,
 	}))!;
 

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import {ipcRenderer as ipc} from 'electron-better-ipc';
 import {is} from 'electron-util';
-import elementReady = require('element-ready');
+import elementReady from 'element-ready';
 import {nativeTheme} from '@electron/remote';
 import selectors from './browser/selectors';
 import {toggleVideoAutoplay} from './autoplay';

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -912,7 +912,7 @@ async function sendReply(message: string): Promise<void> {
 	inputField.focus();
 	insertMessageText(message, inputField);
 
-	const sendButton = await elementReady<HTMLElement>('._30yy._38lh', {stopOnDomReady: false});
+	const sendButton = await elementReady('._30yy._38lh', {stopOnDomReady: false});
 	if (!sendButton) {
 		console.error('Could not find send button');
 		return;


### PR DESCRIPTION
This fixes high CPU usage (for me, at least) as mentioned in https://github.com/sindresorhus/caprine/issues/2107.  I was seeing the same thing, close to 100% of a CPU being used on my 4 core / 8 thread system, whenever the Caprine window is open.  The offending process is the renderer process for electron, specifically the one with the `--no-sandbox` argument.

I was able to use profiling in the devtools and determined `element-ready` to be the cause.  Upgrading `element-ready` to 6.x or 7.x (and fixing the import in `source/browser.ts`) resolves it for me.  CPU will still spike when interacting with the application, but at idle is back to 1-2%.

Reverting `element-ready` back to ^5.0.0 brings the issue back.  I did not dig into the changes in `element-ready` to understand why this happens, just my observation that this does resolve the CPU issue.