### PR TITLE
Include Marketplace and other unread messages in tray icon number

### DIFF
--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -270,7 +270,7 @@ async function updateTrayIcon(): Promise<void> {
 		const messageNumber = element?.ariaLabel?.match(/\d+/g);
 
 		if (messageNumber) {
-			messageCount += parseInt(messageNumber[0], 10);
+			messageCount += Number.parseInt(messageNumber[0], 10);
 		}
 	}
 

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -270,7 +270,7 @@ async function updateTrayIcon(): Promise<void> {
 		const messageNumber = element?.ariaLabel?.match(/\d+/g);
 
 		if (messageNumber) {
-			messageCount += parseInt(messageNumber[0]);
+			messageCount += parseInt(messageNumber[0], 10);
 		}
 	}
 

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -260,12 +260,20 @@ function countUnread(mutationsList: MutationRecord[]): void {
 }
 
 async function updateTrayIcon(): Promise<void> {
-	const chatsIcon = await elementReady(selectors.chatsIcon, {
-		stopOnDomReady: false,
-	});
+	let messageCount = 0;
 
-	// Extract messageCount from ariaLabel
-	const messageCount = chatsIcon?.ariaLabel?.match(/\d+/g) ?? 0;
+	await elementReady(selectors.chatsIcon, {stopOnDomReady: false});
+
+	// Count unread messages in Chats, Marketplace, etc.
+	for (const element of document.querySelectorAll<HTMLElement>(selectors.chatsIcon)) {
+		// Extract messageNumber from ariaLabel
+		const messageNumber = element?.ariaLabel?.match(/\d+/g);
+
+		if (messageNumber) {
+			messageCount += parseInt(messageNumber[0]);
+		}
+	}
+
 	ipc.callMain('update-tray-icon', messageCount);
 }
 


### PR DESCRIPTION
This will loop through _all_ the chat categories (Chats, People, Marketplace, Message Requests, Archive) and extract any numbers in its `ariaLabel`. While I don't expect People or Archive to have unread items, this will still loop through them. This is built off of discussion in #2109 with @stkrknds and @sgtcoder.

_Technically,_ the `elementReady()` only waits for the first element (Chats), but it still seems to work as expected after startup.

One strange thing: if you have unread Marketplace messages when Caprine starts up, it won't load this number until Marketplace is selected. But this is an issue with Messenger.com itself, not with Caprine.