### PR TITLE
Apply Chats title margin for MacOS only

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -49,7 +49,7 @@ body {
 	-webkit-app-region: no-drag;
 }
 /* View label above conversation list margin */
-[role='navigation'] .x1heor9g.x1qlqyl8.x1pd3egz.x1a2a7pz {
+.os-darwin [role='navigation'] .x1heor9g.x1qlqyl8.x1pd3egz.x1a2a7pz {
 	margin-left: 60px;
 }
 


### PR DESCRIPTION
Fixes #2021.

![Chats title with no margin](https://github.com/sindresorhus/caprine/assets/17033543/12904371-7e91-4bab-99fa-c57bcd8ec472)
