### PR TITLE
Lint fixes from recent dependency bumps

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -166,7 +166,7 @@ html.dark-mode ._9xq0 {
 /* Removing top gap */
 /* TODO: Remove when fixed by fb */
 .__fb-dark-mode {
-	--header-height: 0px !important;
+	--header-height: 0 !important;
 }
 
 /* Message list: fix for received messages text color in dark mode */

--- a/package.json
+++ b/package.json
@@ -64,14 +64,12 @@
 		],
 		"rules": {
 			"@typescript-eslint/ban-ts-comment": "off",
-			"@typescript-eslint/consistent-type-definitions": "off",
 			"@typescript-eslint/consistent-type-imports": "off",
 			"@typescript-eslint/naming-convention": "off",
 			"@typescript-eslint/no-floating-promises": "off",
 			"@typescript-eslint/no-loop-func": "off",
 			"@typescript-eslint/no-non-null-assertion": "off",
 			"@typescript-eslint/no-require-imports": "off",
-			"@typescript-eslint/no-unnecessary-type-assertion": "off",
 			"@typescript-eslint/no-unsafe-argument": "off",
 			"@typescript-eslint/no-unsafe-assignment": "off",
 			"@typescript-eslint/no-unsafe-call": "off",
@@ -81,23 +79,15 @@
 			"import/no-anonymous-default-export": "off",
 			"import/no-cycle": "off",
 			"n/file-extension-in-import": "off",
-			"no-warning-comments": "off",
-			"object-curly-newline": "off",
-			"unicorn/no-typeof-undefined": "off",
 			"unicorn/prefer-at": "off",
 			"unicorn/prefer-module": "off",
-			"unicorn/prefer-string-replace-all": "off",
-			"unicorn/prefer-top-level-await": "off",
-			"unicorn/prevent-abbreviations": "off",
-			"unicorn/switch-case-braces": "off"
+			"unicorn/prefer-top-level-await": "off"
 		}
 	},
 	"stylelint": {
 		"extends": "stylelint-config-xo",
 		"rules": {
-			"comment-word-disallowed-list": null,
 			"declaration-no-important": null,
-			"length-zero-no-unit": null,
 			"no-descending-specificity": null,
 			"no-duplicate-selectors": null,
 			"rule-empty-line-before": null,

--- a/source/autoplay.ts
+++ b/source/autoplay.ts
@@ -54,11 +54,11 @@ function disableVideoAutoplay(videos: NodeListOf<HTMLVideoElement>): void {
 		} = firstParent;
 
 		const style = parentWithBackground.style || window.getComputedStyle(parentWithBackground);
-		const backgroundImageSrc = style.backgroundImage.slice(4, -1).replace(/"/g, '');
+		const backgroundImageSource = style.backgroundImage.slice(4, -1).replaceAll(/"/, '');
 
 		// Create the image to replace the video as a placeholder
 		const image = document.createElement('img');
-		image.setAttribute('src', backgroundImageSrc);
+		image.setAttribute('src', backgroundImageSource);
 		image.classList.add('disabledAutoPlayImgTopRadius');
 
 		// If it's a video without a source title bar at the bottom,

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -50,7 +50,7 @@ async function isNewSidebar(): Promise<boolean> {
 
 async function withSettingsMenu(callback: () => Promise<void> | void): Promise<void> {
 	// Wait for navigation pane buttons to show up
-	const settingsMenu = await elementReady(selectors.userMenuNewSidebar, {stopOnDomReady: false})!;
+	const settingsMenu = await elementReady(selectors.userMenuNewSidebar, {stopOnDomReady: false});
 
 	await withMenu(settingsMenu as HTMLElement, callback);
 }
@@ -260,7 +260,7 @@ async function toggleSounds({checked}: IToggleSounds): Promise<void> {
 	const shouldClosePreferences = await openHiddenPreferences();
 
 	const soundsCheckbox = document.querySelector<HTMLInputElement>(`${selectors.preferencesSelector} ${selectors.messengerSoundsSelector}`)!;
-	if (typeof checked === 'undefined' || checked !== soundsCheckbox.checked) {
+	if (checked === undefined || checked !== soundsCheckbox.checked) {
 		soundsCheckbox.click();
 	}
 
@@ -412,12 +412,16 @@ async function updateVibrancy(): Promise<void> {
 	const vibrancy = await ipc.callMain<undefined, 'sidebar' | 'none' | 'full'>('get-config-vibrancy');
 
 	switch (vibrancy) {
-		case 'sidebar':
+		case 'sidebar': {
 			classList.add('sidebar-vibrancy');
 			break;
-		case 'full':
+		}
+
+		case 'full': {
 			classList.add('full-vibrancy');
 			break;
+		}
+
 		default:
 	}
 
@@ -432,15 +436,21 @@ async function updateSidebar(): Promise<void> {
 	const sidebar = await ipc.callMain<undefined, 'default' | 'hidden' | 'narrow' | 'wide'>('get-config-sidebar');
 
 	switch (sidebar) {
-		case 'hidden':
+		case 'hidden': {
 			classList.add('sidebar-hidden');
 			break;
-		case 'narrow':
+		}
+
+		case 'narrow': {
 			classList.add('sidebar-force-narrow');
 			break;
-		case 'wide':
+		}
+
+		case 'wide': {
 			classList.add('sidebar-force-wide');
 			break;
+		}
+
 		default:
 	}
 }
@@ -460,15 +470,15 @@ function renderOverlayIcon(messageCount: number): HTMLCanvasElement {
 	canvas.width = 128;
 	canvas.style.letterSpacing = '-5px';
 
-	const ctx = canvas.getContext('2d')!;
-	ctx.fillStyle = '#f42020';
-	ctx.beginPath();
-	ctx.ellipse(64, 64, 64, 64, 0, 0, 2 * Math.PI);
-	ctx.fill();
-	ctx.textAlign = 'center';
-	ctx.fillStyle = 'white';
-	ctx.font = '90px sans-serif';
-	ctx.fillText(String(Math.min(99, messageCount)), 64, 96);
+	const context = canvas.getContext('2d')!;
+	context.fillStyle = '#f42020';
+	context.beginPath();
+	context.ellipse(64, 64, 64, 64, 0, 0, 2 * Math.PI);
+	context.fill();
+	context.textAlign = 'center';
+	context.fillStyle = 'white';
+	context.font = '90px sans-serif';
+	context.fillText(String(Math.min(99, messageCount)), 64, 96);
 
 	return canvas;
 }

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -22,13 +22,13 @@ function drawIcon(size: number, img?: HTMLImageElement): HTMLCanvasElement {
 		canvas.width = size + padding.left + padding.right;
 		canvas.height = size + padding.top + padding.bottom;
 
-		const ctx = canvas.getContext('2d')!;
-		ctx.beginPath();
-		ctx.arc((size / 2) + padding.left, (size / 2) + padding.top, (size / 2), 0, Math.PI * 2, true);
-		ctx.closePath();
-		ctx.clip();
+		const context = canvas.getContext('2d')!;
+		context.beginPath();
+		context.arc((size / 2) + padding.left, (size / 2) + padding.top, (size / 2), 0, Math.PI * 2, true);
+		context.closePath();
+		context.clip();
 
-		ctx.drawImage(img, padding.left, padding.top, size, size);
+		context.drawImage(img, padding.left, padding.top, size, size);
 	} else {
 		canvas.width = 0;
 		canvas.height = 0;
@@ -63,13 +63,13 @@ async function createIcons(element: HTMLElement, url: string): Promise<void> {
 	element.setAttribute(icon.read, canvas.toDataURL());
 
 	const markerSize = 8;
-	const ctx = canvas.getContext('2d')!;
+	const context = canvas.getContext('2d')!;
 
-	ctx.fillStyle = '#f42020';
-	ctx.beginPath();
-	ctx.ellipse(canvas.width - markerSize, markerSize, markerSize, markerSize, 0, 0, 2 * Math.PI);
-	ctx.closePath();
-	ctx.fill();
+	context.fillStyle = '#f42020';
+	context.beginPath();
+	context.ellipse(canvas.width - markerSize, markerSize, markerSize, markerSize, 0, 0, 2 * Math.PI);
+	context.closePath();
+	context.fill();
 
 	element.setAttribute(icon.unread, canvas.toDataURL());
 }
@@ -111,8 +111,8 @@ async function getLabel(element: HTMLElement): Promise<string> {
 
 	const emojis: HTMLElement[] = [];
 	if (element !== null) {
-		for (const element_curr of element.children) {
-			emojis.push(element_curr as HTMLElement);
+		for (const elementCurrent of element.children) {
+			emojis.push(elementCurrent as HTMLElement);
 		}
 	}
 
@@ -169,7 +169,7 @@ export async function sendConversationList(): Promise<void> {
 	ipc.callMain('conversations', conversationsToRender);
 }
 
-function genStringFromNode(element: Element): string | undefined {
+function generateStringFromNode(element: Element): string | undefined {
 	const cloneElement = element.cloneNode(true) as Element;
 	let emojiString;
 
@@ -217,9 +217,9 @@ function countUnread(mutationsList: MutationRecord[]): void {
 
 	// Check latest mutation first
 	for (const mutation of unreadMutations.reverse()) {
-		const curr = (mutation.target.parentElement as Element).closest(selectors.conversationSidebarSelector)!;
+		const current = (mutation.target.parentElement as Element).closest(selectors.conversationSidebarSelector)!;
 
-		const href = curr.closest('[role="link"]')?.getAttribute('href');
+		const href = current.closest('[role="link"]')?.getAttribute('href');
 
 		if (!href) {
 			continue;
@@ -228,21 +228,21 @@ function countUnread(mutationsList: MutationRecord[]): void {
 		// It is possible to have multiple mutations for the same conversation, but we only want one notification.
 		// So if the current conversation has already been checked, continue.
 		// Additionally if the conversation is not unread, then also continue.
-		if (alreadyChecked.includes(href) || !curr.querySelector('.' + selectors.conversationSidebarUnreadDot.replace(/ /g, '.'))) {
+		if (alreadyChecked.includes(href) || !current.querySelector('.' + selectors.conversationSidebarUnreadDot.replaceAll(/ /, '.'))) {
 			continue;
 		}
 
 		alreadyChecked.push(href);
 
 		// Get the image data URI from the parent of the author/text
-		const imgUrl = curr.querySelector('img')?.dataset.caprineIcon;
-		const textOptions = curr.querySelectorAll(selectors.conversationSidebarTextSelector);
+		const imgUrl = current.querySelector('img')?.dataset.caprineIcon;
+		const textOptions = current.querySelectorAll(selectors.conversationSidebarTextSelector);
 		// Get the author and text of the new message
 		const titleTextNode = textOptions[0];
 		const bodyTextNode = textOptions[1];
 
-		const titleText = genStringFromNode(titleTextNode);
-		const bodyText = genStringFromNode(bodyTextNode);
+		const titleText = generateStringFromNode(titleTextNode);
+		const bodyText = generateStringFromNode(bodyTextNode);
 
 		if (!bodyText || !titleText || !imgUrl) {
 			continue;

--- a/source/config.ts
+++ b/source/config.ts
@@ -250,18 +250,18 @@ function updateThemeSetting(store: Store<StoreType>): void {
 
 	if (is.macos && followSystemAppearance) {
 		store.set('theme', 'system');
-	} else if (typeof darkMode !== 'undefined') {
+	} else if (darkMode !== undefined) {
 		store.set('theme', darkMode ? 'dark' : 'light');
 	} else if (!store.has('theme')) {
 		store.set('theme', 'system');
 	}
 
-	if (typeof darkMode !== 'undefined') {
+	if (darkMode !== undefined) {
 		// @ts-expect-error
 		store.delete('darkMode');
 	}
 
-	if (typeof followSystemAppearance !== 'undefined') {
+	if (followSystemAppearance !== undefined) {
 		// @ts-expect-error
 		store.delete('followSystemAppearance');
 	}

--- a/source/conversation.d.ts
+++ b/source/conversation.d.ts
@@ -1,6 +1,6 @@
-interface Conversation {
+type Conversation = {
 	label: string;
 	selected: boolean;
 	unread: boolean;
 	icon: string;
-}
+};

--- a/source/emoji.ts
+++ b/source/emoji.ts
@@ -219,12 +219,17 @@ enum EmojiStyleCode {
 
 function codeForEmojiStyle(style: EmojiStyle): EmojiStyleCode {
 	switch (style) {
-		case 'facebook-2-2':
+		case 'facebook-2-2': {
 			return EmojiStyleCode.Facebook22;
-		case 'messenger-1-0':
+		}
+
+		case 'messenger-1-0': {
 			return EmojiStyleCode.Messenger10;
-		default:
+		}
+
+		default: {
 			return EmojiStyleCode.Facebook30;
+		}
 	}
 }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -25,7 +25,12 @@ import doNotDisturb from '@sindresorhus/do-not-disturb';
 import updateAppMenu from './menu';
 import config, {StoreType} from './config';
 import tray from './tray';
-import {sendAction, sendBackgroundAction, messengerDomain, stripTrackingFromUrl} from './util';
+import {
+	sendAction,
+	sendBackgroundAction,
+	messengerDomain,
+	stripTrackingFromUrl,
+} from './util';
 import {process as processEmojiUrl} from './emoji';
 import ensureOnline from './ensure-online';
 import {setUpMenuBarMode} from './menu-bar-mode';
@@ -143,12 +148,12 @@ function updateOverlayIcon({data, text}: {data: string; text: string}): void {
 	mainWindow.setOverlayIcon(img, text);
 }
 
-interface BeforeSendHeadersResponse {
+type BeforeSendHeadersResponse = {
 	cancel?: boolean;
 	requestHeaders?: Record<string, string>;
-}
+};
 
-interface OnSendHeadersDetails {
+type OnSendHeadersDetails = {
 	id: number;
 	url: string;
 	method: string;
@@ -157,7 +162,7 @@ interface OnSendHeadersDetails {
 	referrer: string;
 	timestamp: number;
 	requestHeaders: Record<string, string>;
-}
+};
 
 function enableHiresResources(): void {
 	const scaleFactor = Math.max(
@@ -500,14 +505,17 @@ function createMainWindow(): BrowserWindow {
 			if (details.url === 'about:blank' || details.url === 'about:blank#blocked') {
 				if (details.frameName !== 'about:blank') {
 					// Voice/video call popup
-					return {action: 'allow', overrideBrowserWindowOptions: {
-						show: true,
-						titleBarStyle: 'default',
-						webPreferences: {
-							nodeIntegration: false,
-							preload: path.join(__dirname, 'browser-call.js'),
+					return {
+						action: 'allow',
+						overrideBrowserWindowOptions: {
+							show: true,
+							titleBarStyle: 'default',
+							webPreferences: {
+								nodeIntegration: false,
+								preload: path.join(__dirname, 'browser-call.js'),
+							},
 						},
-					}};
+					};
 				}
 			} else {
 				const url = stripTrackingFromUrl(details.url);

--- a/source/menu-bar-mode.ts
+++ b/source/menu-bar-mode.ts
@@ -1,4 +1,9 @@
-import {app, globalShortcut, BrowserWindow, Menu} from 'electron';
+import {
+	app,
+	globalShortcut,
+	BrowserWindow,
+	Menu,
+} from 'electron';
 import {is} from 'electron-util';
 import config from './config';
 import tray from './tray';

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -1,6 +1,12 @@
 import * as path from 'node:path';
 import {existsSync, writeFileSync} from 'node:fs';
-import {app, shell, Menu, MenuItemConstructorOptions, dialog} from 'electron';
+import {
+	app,
+	shell,
+	Menu,
+	MenuItemConstructorOptions,
+	dialog,
+} from 'electron';
 import {
 	is,
 	appMenu,
@@ -11,7 +17,13 @@ import {
 } from 'electron-util';
 import config from './config';
 import getSpellCheckerLanguages from './spell-checker';
-import {sendAction, showRestartDialog, getWindow, toggleTrayIcon, toggleLaunchMinimized} from './util';
+import {
+	sendAction,
+	showRestartDialog,
+	getWindow,
+	toggleTrayIcon,
+	toggleLaunchMinimized,
+} from './util';
 import {generateSubmenu as generateEmojiSubmenu} from './emoji';
 import {toggleMenuBarMode} from './menu-bar-mode';
 import {caprineIconPath} from './constants';

--- a/source/notification-event.d.ts
+++ b/source/notification-event.d.ts
@@ -1,7 +1,7 @@
-interface NotificationEvent {
+type NotificationEvent = {
 	id: number;
 	title: string;
 	body: string;
 	icon: string;
 	silent: boolean;
-}
+};

--- a/source/notifications-isolated.ts
+++ b/source/notifications-isolated.ts
@@ -1,4 +1,4 @@
-((window, Notification) => {
+((window, notification) => {
 	const notifications = new Map<number, Notification>();
 
 	// Handle events sent from the browser process
@@ -39,7 +39,7 @@
 
 	let counter = 1;
 
-	const AugmentedNotification = Object.assign(
+	const augmentedNotification = Object.assign(
 		class {
 			private readonly _id: number;
 
@@ -47,11 +47,11 @@
 				// According to https://github.com/sindresorhus/caprine/pull/637, the Notification
 				// constructor can be called with non-string title and body.
 				let {body} = options;
-				const bodyProps = (body as any).props;
-				body = bodyProps ? bodyProps.content[0] : options.body;
+				const bodyProperties = (body as any).props;
+				body = bodyProperties ? bodyProperties.content[0] : options.body;
 
-				const titleProps = (title as any).props;
-				title = titleProps ? titleProps.content[0] : title;
+				const titleProperties = (title as any).props;
+				title = titleProperties ? titleProperties.content[0] : title;
 
 				this._id = counter++;
 
@@ -74,8 +74,8 @@
 			// No-op, but Messenger expects this method to be present
 			close(): void {} // eslint-disable-line @typescript-eslint/no-empty-function
 		},
-		Notification,
+		notification,
 	);
 
-	Object.assign(window, {Notification: AugmentedNotification});
+	Object.assign(window, {notification: augmentedNotification});
 })(window, Notification);

--- a/source/notifications.d.ts
+++ b/source/notifications.d.ts
@@ -1,9 +1,9 @@
-interface NotificationCallback {
+type NotificationCallback = {
 	callbackName: keyof Notification;
 	id: number;
-}
+};
 
-interface NotificationReplyCallback extends NotificationCallback {
+type NotificationReplyCallback = NotificationCallback & {
 	previousConversation: number;
 	reply: string;
-}
+};

--- a/source/tray.ts
+++ b/source/tray.ts
@@ -1,5 +1,11 @@
 import * as path from 'node:path';
-import {app, Menu, Tray, BrowserWindow, MenuItemConstructorOptions} from 'electron';
+import {
+	app,
+	Menu,
+	Tray,
+	BrowserWindow,
+	MenuItemConstructorOptions,
+} from 'electron';
 import {is} from 'electron-util';
 import config from './config';
 import {toggleMenuBarMode} from './menu-bar-mode';

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,7 +1,7 @@
-export interface IToggleSounds {
+export type IToggleSounds = {
 	checked: boolean;
-}
+};
 
-export interface IToggleMuteNotifications {
+export type IToggleMuteNotifications = {
 	defaultStatus: boolean;
-}
+};

--- a/source/util.ts
+++ b/source/util.ts
@@ -1,4 +1,9 @@
-import {app, BrowserWindow, dialog, Menu} from 'electron';
+import {
+	app,
+	BrowserWindow,
+	dialog,
+	Menu,
+} from 'electron';
 import {ipcMain} from 'electron-better-ipc';
 import {is} from 'electron-util';
 import config from './config';
@@ -9,18 +14,18 @@ export function getWindow(): BrowserWindow {
 	return win;
 }
 
-export function sendAction<T>(action: string, args?: T): void {
+export function sendAction<T>(action: string, arguments_?: T): void {
 	const win = getWindow();
 
 	if (is.macos) {
 		win.restore();
 	}
 
-	ipcMain.callRenderer(win, action, args);
+	ipcMain.callRenderer(win, action, arguments_);
 }
 
-export async function sendBackgroundAction<T, ReturnValue>(action: string, args?: T): Promise<ReturnValue> {
-	return ipcMain.callRenderer<T, ReturnValue>(getWindow(), action, args);
+export async function sendBackgroundAction<T, ReturnValue>(action: string, arguments_?: T): Promise<ReturnValue> {
+	return ipcMain.callRenderer<T, ReturnValue>(getWindow(), action, arguments_);
 }
 
 export function showRestartDialog(message: string): void {


### PR DESCRIPTION
Recent chore (d1b2e14b17ae0ec6a75d47967a24c891c481199d) upgraded some dependency versions, which required some `xo` and `stylelint` rule exceptions to be added. I reverted most of the rule exceptions that were added and cleaned up the code that was breaking the rules.