### PR TITLE
Update selector for chat view menu

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -41,9 +41,9 @@ async function withMenu(
 
 async function isNewSidebar(): Promise<boolean> {
 	// TODO: stopOnDomReady might not be needed
-	await elementReady('[role=navigation] > div > div', {stopOnDomReady: false});
+	await elementReady(selectors.leftSidebar, {stopOnDomReady: false});
 
-	const sidebars = document.querySelectorAll<HTMLElement>('[role=navigation] > div > div');
+	const sidebars = document.querySelectorAll<HTMLElement>(selectors.leftSidebar);
 
 	return sidebars.length === 2;
 }
@@ -85,12 +85,10 @@ async function selectOtherListViews(itemNumber: number): Promise<void> {
 
 	if (newSidebar) {
 		const items = document.querySelectorAll<HTMLElement>(
-			`${selectors.viewsMenu} > span > a`,
+			`${selectors.viewsMenu} span > a`,
 		);
 
 		const selector = itemNumber <= items.length ? items[itemNumber - 1] : null;
-
-		console.log(selector);
 
 		if (selector) {
 			selector.click();

--- a/source/browser/selectors.ts
+++ b/source/browser/selectors.ts
@@ -1,5 +1,5 @@
 export default {
-	leftSidebar: '[role="navigation"] > div > div', // ! Tray icon dependency
+	leftSidebar: '[role="navigation"][class="x9f619 x1n2onr6 x1ja2u2z x78zum5 xdt5ytf x2lah0s x193iq5w xeuugli"] > div > div', // ! Tray icon dependency
 	chatsIcon: '[class="x9f619 x1n2onr6 x1ja2u2z x78zum5 xdt5ytf x2lah0s x193iq5w xdj266r"] a', // ! Tray icon dependency
 	conversationList: '[role=navigation] [role=grid] [class="x1n2onr6"]',
 	conversationSelector: '[role=main] [role=grid]',
@@ -15,7 +15,7 @@ export default {
 	closePreferencesButton: 'div[role=dialog] > div > div > div:nth-child(2) > [role=button]',
 	userMenu: '.qi72231t.o9w3sbdw.nu7423ey.tav9wjvu.flwp5yud.tghlliq5.gkg15gwv.s9ok87oh.s9ljgwtm.lxqftegz.bf1zulr9.frfouenu.bonavkto.djs4p424.r7bn319e.bdao358l.fsf7x5fv.tgm57n0e.jez8cy9q.s5oniofx.m8h3af8h.l7ghb35v.kjdc1dyq.kmwttqpk.dnr7xe2t.aeinzg81.srn514ro.oxkhqvkx.rl78xhln.nch0832m.om3e55n1.cr00lzj9.rn8ck1ys.s3jn8y49.g4tp4svg.o9erhkwx.dzqi5evh.hupbnkgi.hvb2xoa8.fxk3tzhb.jl2a5g8c.f14ij5to.l3ldwz01.icdlwmnq > .aglvbi8b.om3e55n1.i8zpp7h3.g4tp4svg',
 	userMenuNewSidebar: '[role=navigation]  > div >  div:nth-child(2) > div > div > div:nth-child(1) [role=button]',
-	viewsMenu: '.x9f619.x1n2onr6.x1ja2u2z.x78zum5.xdt5ytf.x2lah0s.x193iq5w.xurb0ha.x1sxyh0.xdj266r',
+	viewsMenu: '.x9f619.x1n2onr6.x1ja2u2z.x78zum5.xdt5ytf.x2lah0s.x193iq5w.xdj266r',
 	selectedConversation: '[role=navigation] [role=grid] [role=row] [role=gridcell] [role=link][aria-current]',
 	// ! Very fragile selector (most likely cause of hidden dialog issue)
 	preferencesSelector: 'div[role=dialog][class="x1n2onr6 x1ja2u2z x1afcbsf x78zum5 xdt5ytf x1a2a7pz x6ikm8r x10wlt62 x71s49j x1jx94hy x1g2kw80 xxadwq3 x16n5opg x3hh19s xl7ujzl x1kl8bxo xhkep3z xb3b7hn xwhkkir xeb55yp x17omtbh"]',


### PR DESCRIPTION
Using "role=navigation" is no longer unique enough to get the view menu. This led to 7 match results (at least in my case) for `'[role=navigation] > div > div'`, which defaults to the `selectMenuItem()` use case.

[The users' interfaces seem to be more unified now, so we could consider eliminating the "new sidebar" checks too, since those may be artifacts from multiple versions ago.]

Fixes #2178.