### PR TITLE
Update website

### DIFF
--- a/packages/rpm/caprine.spec
+++ b/packages/rpm/caprine.spec
@@ -7,7 +7,7 @@ Release:        1%{?dist}
 Summary:        Elegant Facebook Messenger desktop app
 
 License:        MIT
-URL:            https://sindresorhus.com/caprine/
+URL:            https://github.com/sindresorhus/caprine/
 Source0:        https://github.com/sindresorhus/caprine/archive/refs/tags/v%{version}.tar.gz
 Source1:        %{name}.desktop
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <div align="center">
 	<br>
 	<br>
-	<a href="https://sindresorhus.com/caprine">
+	<a href="https://github.com/sindresorhus/caprine">
 		<img src="media/AppIcon-readme.png" width="200" height="200">
 	</a>
 	<h1>Caprine</h1>
@@ -17,7 +17,7 @@
 		Caprine is feature complete. However, we welcome contributions for improvements and bug fixes.
 	</b>
 	<br>
-		<a href="https://sindresorhus.com/caprine">
+		<a href="https://github.com/sindresorhus/caprine">
 		Website
 		</a>
 	<br>
@@ -49,7 +49,7 @@
 
 *macOS 10.12+ (Intel and Apple Silicon), Linux (x64 and arm64), and Windows 10+ (64-bit) are supported.*
 
-Download the latest version on the [website](https://sindresorhus.com/caprine) or below.
+Download the latest version on the [website](https://github.com/sindresorhus/caprine) or below.
 
 ### macOS
 

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -692,7 +692,7 @@ Press Command/Ctrl+R in Caprine to see your changes.
 	const helpSubmenu: MenuItemConstructorOptions[] = [
 		openUrlMenuItem({
 			label: 'Website',
-			url: 'https://sindresorhus.com/caprine',
+			url: 'https://github.com/sindresorhus/caprine',
 		}),
 		openUrlMenuItem({
 			label: 'Source Code',
@@ -731,7 +731,7 @@ ${debugInfo()}`;
 				icon: caprineIconPath,
 				copyright: 'Created by Sindre Sorhus',
 				text: 'Maintainers:\nDušan Simić\nLefteris Garyfalakis\nMichael Quevillon\nNikolas Spiridakis',
-				website: 'https://sindresorhus.com/caprine',
+				website: 'https://github.com/sindresorhus/caprine',
 			}),
 		);
 	}


### PR DESCRIPTION
Since https://sindresorhus.com/caprine isn't available anymore, update it to point to the GitHub project
(https://github.com/sindresorhus/caprine).