### PR TITLE
Remove Active Contacts view

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -133,10 +133,6 @@ html.private-mode [href^='https://www.facebook.com/1'] .b6ax4al1.i54nktwv.z2vv26
 html.private-mode [role='navigation'] [role='row'] .b6ax4al1.gvxzyvdx {
 	filter: blur(5px);
 }
-/* Chat list: active contacts */
-html.private-mode [role='navigation'] .s9ok87oh.bf1zulr9.s9ljgwtm.lxqftegz.frfouenu.r7bn319e.bonavkto.djs4p424.bdao358l.alzwoclg.cgu29s5g.i15ihif8.sl27f92c.m8h3af8h.l7ghb35v.kjdc1dyq.kmwttqpk.aeinzg81.srn514ro.rl78xhln.om3e55n1.g4tp4svg.i85zmo3j.jl2a5g8c.b0eko5f3.fwlpnqze.il7dmu95z {
-	filter: blur(5px);
-}
 /* Chat list: person tiny heads */
 html.private-mode [role='row'] .aglvbi8b.om3e55n1.i8zpp7h3.g4tp4svg {
 	filter: blur(3px);

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -297,20 +297,16 @@ ipc.answerMain('show-chats-view', async () => {
 	await selectOtherListViews(1);
 });
 
-ipc.answerMain('show-people-view', async () => {
+ipc.answerMain('show-marketplace-view', async () => {
 	await selectOtherListViews(2);
 });
 
-ipc.answerMain('show-marketplace-view', async () => {
+ipc.answerMain('show-requests-view', async () => {
 	await selectOtherListViews(3);
 });
 
-ipc.answerMain('show-requests-view', async () => {
-	await selectOtherListViews(4);
-});
-
 ipc.answerMain('show-archive-view', async () => {
-	await selectOtherListViews(5);
+	await selectOtherListViews(4);
 });
 
 ipc.answerMain('toggle-video-autoplay', () => {

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -555,12 +555,6 @@ Press Command/Ctrl+R in Caprine to see your changes.
 			},
 		},
 		{
-			label: 'Show Active Contacts',
-			click() {
-				sendAction('show-people-view');
-			},
-		},
-		{
 			label: 'Show Marketplace Chats',
 			click() {
 				sendAction('show-marketplace-view');


### PR DESCRIPTION
The "Active Contacts" view and menu option has been removed from the website's interface, so this is updating the app's view section options.

This builds on #2182, since it relies on the sidebar selector.