### PR TITLE
Use preferences window class info instead of aria-label

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -358,7 +358,6 @@ async function observeTheme(): Promise<void> {
 		observerNew.observe(menuElements, {childList: true});
 	}
 
-	// Attribute notation needed here to guarantee exact (not partial) match.
 	const modalElements = await elementReady(selectors.preferencesSelector, {stopOnDomReady: false});
 	if (modalElements) {
 		observerNew.observe(modalElements, {childList: true});

--- a/source/browser/selectors.ts
+++ b/source/browser/selectors.ts
@@ -17,7 +17,8 @@ export default {
 	userMenuNewSidebar: '[role=navigation]  > div >  div:nth-child(2) > div > div > div:nth-child(1) [role=button]',
 	viewsMenu: '.x9f619.x1n2onr6.x1ja2u2z.x78zum5.xdt5ytf.x2lah0s.x193iq5w.xdj266r',
 	selectedConversation: '[role=navigation] [role=grid] [role=row] [role=gridcell] [role=link][aria-current=page]',
-	preferencesSelector: '[aria-label=Preferences]',
+	// ! Very fragile selector (most likely cause of hidden dialog issue)
+	preferencesSelector: '.x1n2onr6.x1ja2u2z.x1afcbsf.x78zum5.xdt5ytf.x1a2a7pz.x6ikm8r.x10wlt62.x71s49j.x1jx94hy.x1g2kw80.xxadwq3.x16n5opg.x3hh19s.xl7ujzl.x1kl8bxo.xhkep3z.xb3b7hn.xwhkkir.x1n7qst7.x17omtbh:has(.x1l90r2v.x1swvt13.x1pi30zi)',
 	// TODO: Fix this selector for new design
 	messengerSoundsSelector: '._374d ._6bkz',
 	conversationMenuSelectorNewDesign: '[role=menu]',


### PR DESCRIPTION
Using `aria-label` had localization issues that did not work in non-English locales. Using the `class` info is necessary to work across locales. The `:has()` is necessary since the specified parent class is used for all windows (restore chat PIN, other settings windows, etc.).

The selector is likely still fragile due to the amount of back-end changes that are typically made, so I restored the comment.

Fixes #2167.