### PR TITLE
Disable hidden preferences functions

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -424,13 +424,14 @@ async function updateSidebar(): Promise<void> {
 	}
 }
 
-// TODO: Implement this function
 async function updateDoNotDisturb(): Promise<void> {
+	/* TODO: Implement this function
 	const shouldClosePreferences = await openHiddenPreferences();
 
 	if (shouldClosePreferences) {
 		await closePreferences();
 	}
+	*/
 }
 
 function renderOverlayIcon(messageCount: number): HTMLCanvasElement {

--- a/source/index.ts
+++ b/source/index.ts
@@ -382,6 +382,7 @@ function createMainWindow(): BrowserWindow {
 		const firstItem: MenuItemConstructorOptions = {
 			label: 'Mute Notifications',
 			type: 'checkbox',
+			visible: is.development,
 			checked: config.get('notificationsMuted'),
 			async click() {
 				setNotificationsMute(await ipc.callRenderer(mainWindow, 'toggle-mute-notifications'));
@@ -467,6 +468,7 @@ function createMainWindow(): BrowserWindow {
 		}
 
 		if (is.macos) {
+			// TODO: 'update-dnd-mode' is not called
 			ipc.answerRenderer('update-dnd-mode', async (initialSoundsValue: boolean) => {
 				doNotDisturb.on('change', (doNotDisturb: boolean) => {
 					isDNDEnabled = doNotDisturb;
@@ -479,9 +481,10 @@ function createMainWindow(): BrowserWindow {
 			});
 		}
 
-		setNotificationsMute(await ipc.callRenderer(mainWindow, 'toggle-mute-notifications', {
-			defaultStatus: config.get('notificationsMuted'),
-		}));
+		// TODO: Re-enable this when muting notifications is fixed
+		// setNotificationsMute(await ipc.callRenderer(mainWindow, 'toggle-mute-notifications', {
+		// 	defaultStatus: config.get('notificationsMuted'),
+		// }));
 
 		ipc.callRenderer(mainWindow, 'toggle-message-buttons', config.get('showMessageButtons'));
 


### PR DESCRIPTION
Removes all calls to functions that call for the `'hide-preferences-window'` class, which has caused many issues with its volatility. Most of the functions that were using this functionality were not working correctly anyway, so no functionality is lost. These functions should eventually be cleaned up or properly implemented, so I left relevant `TODO` comments.

Should "fix" many outstanding issues, but will go through them separately.