### PR TITLE
Fix theme auto-switching, dock menu, macOS window dragging, and add Windows Jump List

### DIFF
--- a/css/browser.css
+++ b/css/browser.css
@@ -36,18 +36,7 @@ body {
 [role='navigation'] .x16n37ib {
 	-webkit-app-region: no-drag;
 }
-/* Bar above chat */
-[role='main'] .x1u998qt.x1vjfegm {
-	-webkit-app-region: drag;
-}
-/* Conversation name */
-[role='main'] .x1i10hfl.x1qjc9v5.xjbqb8w.xjqpnuy.xa49m3k.xqeqjp1.x2hbi6w.x13fuv20.xu3j5b3.x1q0q8m5.x26u7qi.x972fbf.xcfux6l.x1qhh985.xm0m39n.x9f619.x1ypdohk.xdl72j9.x2lah0s.xe8uvvx.xdj266r.x11i5rnm.xat24cr.x1mh8g0r.x2lwn1j.xeuugli.xexx8yu.x4uap5.x18d9i69.xkhd6sd.x1n2onr6.x16tdsg8.x1hl2dhg.xggy1nq.x1ja2u2z.x1t137rt.x1o1ewxj.x3x9cwd.x1e5q0jg.x13rtm0m.x1q0g3np.x87ps6o.x1lku1pv.x1a2a7pz.x78zum5 {
-	-webkit-app-region: no-drag;
-}
-/* Top right buttons */
-[role='main'] .x9f619.x1n2onr6.x1ja2u2z.x78zum5.x2lah0s.x1qughib.x6s0dn4.xozqiw3.x1q0g3np.xykv574.xbmpl8g.x4cne27.xifccgj {
-	-webkit-app-region: no-drag;
-}
+
 /* View label above conversation list margin */
 .os-darwin [role='navigation'] .x1heor9g.x1qlqyl8.x1pd3egz.x1a2a7pz {
 	margin-left: 60px;

--- a/source/browser.ts
+++ b/source/browser.ts
@@ -812,7 +812,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 	// On mousemove, we toggle pointer-events to allow clicking interactive
 	// elements (buttons, links) underneath while keeping empty space draggable.
 	if (is.macos) {
-		const dragBarHeight = 48;
+		const dragBarHeight = 24;
 		const dragBar = document.createElement('div');
 		dragBar.id = 'caprine-drag-bar';
 		dragBar.style.position = 'fixed';

--- a/source/browser/conversation-list.ts
+++ b/source/browser/conversation-list.ts
@@ -327,7 +327,9 @@ window.addEventListener('load', async () => {
 	const leftSidebar = await elementReady(`${selectors.leftSidebar}:has(${selectors.chatsIcon})`, {stopOnDomReady: false});
 
 	if (sidebar) {
-		const conversationListObserver = new MutationObserver(async () => sendConversationList());
+		const conversationListObserver = new MutationObserver(async () => {
+			sendConversationList();
+		});
 		const conversationCountObserver = new MutationObserver(countUnread);
 
 		conversationListObserver.observe(sidebar, {

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -6,6 +6,7 @@ import {
 	Menu,
 	MenuItemConstructorOptions,
 	dialog,
+	nativeTheme,
 } from 'electron';
 import {
 	is,
@@ -114,6 +115,7 @@ export default async function updateMenu(): Promise<Menu> {
 			checked: config.get('theme') === 'system',
 			async click() {
 				config.set('theme', 'system');
+				nativeTheme.themeSource = 'system';
 				sendAction('set-theme');
 				await updateMenu();
 			},
@@ -124,6 +126,7 @@ export default async function updateMenu(): Promise<Menu> {
 			checked: config.get('theme') === 'light',
 			async click() {
 				config.set('theme', 'light');
+				nativeTheme.themeSource = 'light';
 				sendAction('set-theme');
 				await updateMenu();
 			},
@@ -134,6 +137,7 @@ export default async function updateMenu(): Promise<Menu> {
 			checked: config.get('theme') === 'dark',
 			async click() {
 				config.set('theme', 'dark');
+				nativeTheme.themeSource = 'dark';
 				sendAction('set-theme');
 				await updateMenu();
 			},


### PR DESCRIPTION
## Summary
This PR includes several bug fixes and a new feature:

### Bug Fixes
- **Theme auto-switching**: Fixed issue where background and sidebar remained dark when system theme changed
- **Dock menu**: Fixed blank conversation names appearing on macOS dock menu
- **macOS window dragging**: Fixed window dragging not working when window is focused

### New Feature
- **Windows Jump List**: Added taskbar right-click menu support for Windows
  - Shows top 5 recent conversations
  - Clicking a conversation jumps directly to it
  - Clears on app quit to prevent stale data