### PR TITLE
Reload page on system resume to fix stale Messenger connection

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -12,6 +12,7 @@ import {
 	MenuItemConstructorOptions,
 	systemPreferences,
 	nativeTheme,
+	powerMonitor,
 } from 'electron';
 import {ipcMain as ipc} from 'electron-better-ipc';
 import {autoUpdater} from 'electron-updater';
@@ -429,6 +430,15 @@ function createMainWindow(): BrowserWindow {
 	enableHiresResources();
 
 	const {webContents} = mainWindow;
+
+	// Reload the page on system resume to restore the Messenger connection,
+	// which is lost when the computer sleeps. Wait for network connectivity
+	// before reloading to avoid a blank page on slow reconnects.
+	// See: https://github.com/sindresorhus/caprine/issues/103
+	powerMonitor.on('resume', async () => {
+		await ensureOnline();
+		webContents.reload();
+	});
 
 	webContents.on('dom-ready', async () => {
 		// Set window title to Caprine


### PR DESCRIPTION
## Summary

After a system suspend/wake cycle, the long-poll/WebSocket connection to messenger.com is silently broken — no new messages arrive and sends fail until the user manually presses `Cmd+R`. This is a known issue noted in the code itself (the `electronDebug` call at the top of `index.ts` explicitly keeps debug mode on for this reason).

## Fix

Listen for Electron's `powerMonitor` `resume` event. When the system wakes:
1. Wait for network connectivity via the existing `ensureOnline()` utility (polls every second with `p-wait-for` + `is-online`) to avoid a blank page on slow reconnects — as raised by @veniversum in the issue thread.
2. Reload the webContents to re-establish the Messenger connection.

```ts
powerMonitor.on('resume', async () => {
    await ensureOnline();
    webContents.reload();
});
```

No new dependencies. Uses only Electron built-ins and the already-imported `ensureOnline` helper.

## Testing

1. Open Caprine and confirm messages load.
2. Put the machine to sleep (close lid or `pmset sleepnow`).
3. Wake the machine.
4. Verify new messages arrive without a manual reload.

Fixes #103